### PR TITLE
feat(shared): add env config and logger

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -2,10 +2,14 @@
   "name": "@gamearr/api",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "echo build api",
     "dev": "echo dev api",
     "lint": "echo lint api",
     "test": "echo test api"
+  },
+  "dependencies": {
+    "@gamearr/shared": "workspace:*"
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,1 +1,4 @@
-console.log('api');
+import { config, logger } from '@gamearr/shared';
+
+logger.info('api start');
+console.log(config.dbUrl);

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -2,10 +2,20 @@
   "name": "@gamearr/shared",
   "version": "0.0.0",
   "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
   "scripts": {
-    "build": "echo build shared",
-    "dev": "echo dev shared",
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -w -p tsconfig.json",
     "lint": "echo lint shared",
-    "test": "echo test shared"
+    "test": "tsc -p tsconfig.json && node --test dist/**/*.test.js"
+  },
+  "dependencies": {
+    "pino": "^9.0.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0"
   }
 }

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const VALID_ENV = {
+  DB_URL: 'postgresql://user:pass@localhost:5432/db',
+  REDIS_URL: 'redis://localhost:6379',
+  RAWG_KEY: 'rawg-key',
+  IGDB_CLIENT_ID: 'client-id',
+  IGDB_CLIENT_SECRET: 'client-secret',
+  LIB_ROOT: '/library',
+  DOWNLOADS_ROOT: '/downloads',
+};
+
+const loadConfig = async () => import(`./config.js?${Date.now()}`);
+
+const setEnv = (env: Record<string, string>) => {
+  process.env = { ...env } as NodeJS.ProcessEnv;
+};
+
+test('parses configuration from env', async () => {
+  const original = process.env;
+  setEnv(VALID_ENV);
+  const mod = await loadConfig();
+  assert.equal(mod.config.dbUrl, VALID_ENV.DB_URL);
+  process.env = original;
+});
+
+test('throws when required vars are missing', async () => {
+  const original = process.env;
+  const { DB_URL, ...rest } = VALID_ENV;
+  setEnv(rest);
+  await assert.rejects(loadConfig);
+  process.env = original;
+});

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  DB_URL: z.string().url(),
+  REDIS_URL: z.string(),
+  RAWG_KEY: z.string(),
+  IGDB_CLIENT_ID: z.string(),
+  IGDB_CLIENT_SECRET: z.string(),
+  LIB_ROOT: z.string(),
+  DOWNLOADS_ROOT: z.string(),
+});
+
+const env = envSchema.parse(process.env);
+
+export const config = {
+  dbUrl: env.DB_URL,
+  redisUrl: env.REDIS_URL,
+  rawgKey: env.RAWG_KEY,
+  igdb: {
+    clientId: env.IGDB_CLIENT_ID,
+    clientSecret: env.IGDB_CLIENT_SECRET,
+  },
+  paths: {
+    libRoot: env.LIB_ROOT,
+    downloadsRoot: env.DOWNLOADS_ROOT,
+  },
+};
+
+export type Config = typeof config;
+
+export default config;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,1 +1,2 @@
-export const shared = {};
+export * from './config';
+export * from './logger';

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -1,0 +1,18 @@
+import pino from 'pino';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID } from 'node:crypto';
+
+const store = new AsyncLocalStorage<string>();
+
+export const logger = pino({
+  mixin() {
+    const requestId = store.getStore();
+    return requestId ? { requestId } : {};
+  },
+});
+
+export function withRequestId<T>(fn: () => T, requestId: string = randomUUID()): T {
+  return store.run(requestId, fn);
+}
+
+export default logger;


### PR DESCRIPTION
## Summary
- add environment config using zod
- add pino logger with request id context
- expose shared utilities and consume them in api

## Testing
- `npm test` *(fails: Cannot find module 'zod' and other dependencies)*
- `npx tsc -p apps/api/tsconfig.json --noEmit` *(fails: Cannot find module '@gamearr/shared')*

------
https://chatgpt.com/codex/tasks/task_e_68ad373ea3dc8330bf6ac29168247ae1