### PR TITLE
feat: add docker deploy configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,85 @@
+version: "3.8"
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: gamearr
+      POSTGRES_USER: gamearr
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U gamearr"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    restart: unless-stopped
+    environment:
+      DB_URL: postgres://gamearr:${POSTGRES_PASSWORD}@postgres:5432/gamearr
+      REDIS_URL: redis://redis:6379
+      FRONTEND_URL: http://localhost:5173
+    ports:
+      - "3000:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  worker:
+    build:
+      context: .
+      dockerfile: apps/worker/Dockerfile
+    restart: unless-stopped
+    environment:
+      DB_URL: postgres://gamearr:${POSTGRES_PASSWORD}@postgres:5432/gamearr
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "node", "-e", "process.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    restart: unless-stopped
+    environment:
+      VITE_API_URL: http://api:3000
+    ports:
+      - "5173:5173"
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5173"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+volumes:
+  postgres_data:
+  redis_data:

--- a/infra/helm/gamearr/Chart.yaml
+++ b/infra/helm/gamearr/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: gamearr
+description: Helm chart for the Gamearr application
+version: 0.1.0
+appVersion: "0.0.0"
+type: application

--- a/infra/helm/gamearr/templates/_helpers.tpl
+++ b/infra/helm/gamearr/templates/_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "gamearr.fullname" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/infra/helm/gamearr/templates/api.yaml
+++ b/infra/helm/gamearr/templates/api.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gamearr.fullname" . }}-api
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "gamearr.fullname" . }}-api
+  template:
+    metadata:
+      labels:
+        app: {{ include "gamearr.fullname" . }}-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: api
+          image: {{ .Values.api.image }}
+          ports:
+            - containerPort: 3000
+          envFrom:
+            - secretRef:
+                name: {{ include "gamearr.fullname" . }}-env
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 3000
+            initialDelaySeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources: {{ toYaml .Values.api.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gamearr.fullname" . }}-api
+spec:
+  type: {{ .Values.api.service.type }}
+  ports:
+    - port: {{ .Values.api.service.port }}
+      targetPort: 3000
+  selector:
+    app: {{ include "gamearr.fullname" . }}-api
+---
+{{- if .Values.api.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gamearr.fullname" . }}-api
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gamearr.fullname" . }}-api
+  minReplicas: {{ .Values.api.hpa.minReplicas }}
+  maxReplicas: {{ .Values.api.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.api.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/gamearr/templates/postgres.yaml
+++ b/infra/helm/gamearr/templates/postgres.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gamearr.fullname" . }}-postgres
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.postgres.persistence.size }}
+{{- if .Values.postgres.persistence.storageClass }}
+  storageClassName: {{ .Values.postgres.persistence.storageClass }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gamearr.fullname" . }}-postgres
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "gamearr.fullname" . }}-postgres
+  template:
+    metadata:
+      labels:
+        app: {{ include "gamearr.fullname" . }}-postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          env:
+            - name: POSTGRES_DB
+              value: {{ .Values.postgres.database }}
+            - name: POSTGRES_USER
+              value: {{ .Values.postgres.user }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "gamearr.fullname" . }}-env
+                  key: POSTGRES_PASSWORD
+          ports:
+            - containerPort: {{ .Values.postgres.service.port }}
+          livenessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgres.user }}"]
+            initialDelaySeconds: 10
+          readinessProbe:
+            exec:
+              command: ["pg_isready", "-U", "{{ .Values.postgres.user }}"]
+            initialDelaySeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+          securityContext:
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "gamearr.fullname" . }}-postgres
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gamearr.fullname" . }}-postgres
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.postgres.service.port }}
+      targetPort: {{ .Values.postgres.service.port }}
+  selector:
+    app: {{ include "gamearr.fullname" . }}-postgres
+{{- end }}

--- a/infra/helm/gamearr/templates/redis.yaml
+++ b/infra/helm/gamearr/templates/redis.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "gamearr.fullname" . }}-redis
+spec:
+  accessModes: ["ReadWriteOnce"]
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+{{- if .Values.redis.persistence.storageClass }}
+  storageClassName: {{ .Values.redis.persistence.storageClass }}
+{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gamearr.fullname" . }}-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ include "gamearr.fullname" . }}-redis
+  template:
+    metadata:
+      labels:
+        app: {{ include "gamearr.fullname" . }}-redis
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - containerPort: {{ .Values.redis.service.port }}
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 10
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          securityContext:
+            allowPrivilegeEscalation: false
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ include "gamearr.fullname" . }}-redis
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gamearr.fullname" . }}-redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.redis.service.port }}
+      targetPort: {{ .Values.redis.service.port }}
+  selector:
+    app: {{ include "gamearr.fullname" . }}-redis

--- a/infra/helm/gamearr/templates/secret.yaml
+++ b/infra/helm/gamearr/templates/secret.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "gamearr.fullname" . }}-env
+type: Opaque
+stringData:
+  POSTGRES_PASSWORD: {{ .Values.postgres.password | quote }}
+  {{- if .Values.postgres.enabled }}
+  DB_URL: "{{ printf "postgres://%s:%s@%s-postgres:%d/%s" .Values.postgres.user .Values.postgres.password (include "gamearr.fullname" .) .Values.postgres.service.port .Values.postgres.database }}"
+  {{- else }}
+  DB_URL: {{ .Values.external.dbUrl | quote }}
+  {{- end }}
+  REDIS_URL: "redis://{{ include "gamearr.fullname" . }}-redis:{{ .Values.redis.service.port }}"
+  VITE_API_URL: "http://{{ include "gamearr.fullname" . }}-api:{{ .Values.api.service.port }}"
+  FRONTEND_URL: "http://{{ include "gamearr.fullname" . }}-web:{{ .Values.web.service.port }}"

--- a/infra/helm/gamearr/templates/web-ingress.yaml
+++ b/infra/helm/gamearr/templates/web-ingress.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "gamearr.fullname" . }}-web
+  annotations:
+{{- range $k, $v := .Values.ingress.annotations }}
+    {{ $k }}: {{ $v | quote }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className | quote }}
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+{{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "gamearr.fullname" . }}-web
+                port:
+                  number: {{ .Values.web.service.port }}
+{{- end }}

--- a/infra/helm/gamearr/templates/web.yaml
+++ b/infra/helm/gamearr/templates/web.yaml
@@ -1,0 +1,73 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gamearr.fullname" . }}-web
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "gamearr.fullname" . }}-web
+  template:
+    metadata:
+      labels:
+        app: {{ include "gamearr.fullname" . }}-web
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: web
+          image: {{ .Values.web.image }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gamearr.fullname" . }}-env
+          ports:
+            - containerPort: {{ .Values.web.service.targetPort }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.web.service.targetPort }}
+            initialDelaySeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.web.service.targetPort }}
+            initialDelaySeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources: {{ toYaml .Values.web.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "gamearr.fullname" . }}-web
+spec:
+  type: {{ .Values.web.service.type }}
+  ports:
+    - port: {{ .Values.web.service.port }}
+      targetPort: {{ .Values.web.service.targetPort }}
+  selector:
+    app: {{ include "gamearr.fullname" . }}-web
+---
+{{- if .Values.web.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gamearr.fullname" . }}-web
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gamearr.fullname" . }}-web
+  minReplicas: {{ .Values.web.hpa.minReplicas }}
+  maxReplicas: {{ .Values.web.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.web.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/gamearr/templates/worker.yaml
+++ b/infra/helm/gamearr/templates/worker.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "gamearr.fullname" . }}-worker
+spec:
+  replicas: {{ .Values.worker.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "gamearr.fullname" . }}-worker
+  template:
+    metadata:
+      labels:
+        app: {{ include "gamearr.fullname" . }}-worker
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: worker
+          image: {{ .Values.worker.image }}
+          envFrom:
+            - secretRef:
+                name: {{ include "gamearr.fullname" . }}-env
+          livenessProbe:
+            exec:
+              command: ["node", "-e", "process.exit(0)"]
+            initialDelaySeconds: 10
+          readinessProbe:
+            exec:
+              command: ["node", "-e", "process.exit(0)"]
+            initialDelaySeconds: 10
+          securityContext:
+            allowPrivilegeEscalation: false
+          resources: {{ toYaml .Values.worker.resources | nindent 12 }}
+---
+{{- if .Values.worker.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "gamearr.fullname" . }}-worker
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "gamearr.fullname" . }}-worker
+  minReplicas: {{ .Values.worker.hpa.minReplicas }}
+  maxReplicas: {{ .Values.worker.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.worker.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/infra/helm/gamearr/values.yaml
+++ b/infra/helm/gamearr/values.yaml
@@ -1,0 +1,61 @@
+api:
+  image: node:20-alpine
+  replicas: 1
+  service:
+    type: ClusterIP
+    port: 3000
+  hpa:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+worker:
+  image: node:20-alpine
+  replicas: 1
+  hpa:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+web:
+  image: node:20-alpine
+  replicas: 1
+  service:
+    type: ClusterIP
+    port: 80
+    targetPort: 5173
+  hpa:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 3
+    targetCPUUtilizationPercentage: 80
+postgres:
+  enabled: true
+  image: postgres:16
+  user: gamearr
+  password: changeme
+  database: gamearr
+  service:
+    port: 5432
+  persistence:
+    enabled: true
+    size: 10Gi
+    storageClass: ""
+redis:
+  image: redis:7
+  service:
+    port: 6379
+  persistence:
+    enabled: true
+    size: 1Gi
+    storageClass: ""
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  host: gamearr.local
+  tls:
+    enabled: false
+    secretName: ""
+external:
+  dbUrl: ""


### PR DESCRIPTION
## Summary
- add production docker compose stack with healthchecks and restart policies
- scaffold Helm chart for api, worker, web, postgres and redis

## Testing
- `pnpm test`
- `helm lint infra/helm/gamearr` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b549fd488330a5bcc04d0be446e6