### PR TITLE
feat: add usage disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 Monorepo managed with [Turborepo](https://turbo.build/) and [pnpm](https://pnpm.io/).
 
+## Usage Disclaimer
+
+gamearr does not provide game files. Use this project only with backups of
+games you legally own. You are responsible for complying with the terms of
+service for any providers you access through this software.
+
 ## Workspaces
 
 - `apps/api` – NestJS API server

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -44,6 +44,10 @@ function App() {
         <Route path="/settings" element={<Settings />} />
         <Route path="*" element={<Libraries />} />
       </Routes>
+      <footer className="p-4 text-center text-xs text-gray-500">
+        Use only with games you own and follow the terms of service for all
+        providers.
+      </footer>
     </BrowserRouter>
   );
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,10 @@
 # Documentation
 
+## Usage Disclaimer
+
+gamearr manages backups of games you legally own. Ensure compliance with the
+terms of service for any providers used with this project.
+
 - [Architecture](./architecture.md)
 - [Local Development](./local-dev.md)
 - [Configuration](./configuration.md)


### PR DESCRIPTION
## Summary
- display usage disclaimer in web UI footer
- document requirement to own games and follow provider ToS

## Testing
- `pnpm -w lint`
- `pnpm -w test`

------
https://chatgpt.com/codex/tasks/task_e_68b0e5baecd48330829df826434c121d