### PR TITLE
feat(web): add libraries management

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,10 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.23.0",
-    "sonner": "^2.0.7"
+    "sonner": "^2.0.7",
+    "@hookform/resolvers": "^3.3.4",
+    "react-hook-form": "^7.51.3",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/apps/web/src/pages/Libraries.tsx
+++ b/apps/web/src/pages/Libraries.tsx
@@ -1,60 +1,247 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { toast } from 'sonner';
 import { useApiQuery, useApiMutation } from '../lib/api';
 import { Button } from '../components/ui/button';
 import { Input } from '../components/ui/input';
 
+interface Library {
+  id: string;
+  platformId: string;
+  path: string;
+  lastScannedAt?: string | null;
+}
+
+const schema = z.object({
+  platformId: z.string().min(1, 'Platform is required'),
+  rootPath: z.string().min(1, 'Path is required'),
+});
+
+type FormValues = z.infer<typeof schema>;
+
 export function Libraries() {
   const queryClient = useQueryClient();
-  const { data } = useApiQuery<any[]>({ queryKey: ['libraries'], path: '/libraries' });
-  const [path, setPath] = useState('');
-  const [platformId, setPlatformId] = useState('');
+  const { data } = useApiQuery<Library[]>({
+    queryKey: ['libraries'],
+    path: '/libraries',
+  });
 
-  const addMutation = useApiMutation<any, { path: string; platformId: string }>(
-    (body) => ({
+  const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState<Library | null>(null);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { platformId: '', rootPath: '' },
+  });
+
+  useEffect(() => {
+    if (open) {
+      if (editing) {
+        form.reset({ platformId: editing.platformId, rootPath: editing.path });
+      } else {
+        form.reset({ platformId: '', rootPath: '' });
+      }
+    }
+  }, [open, editing, form]);
+
+  const createMutation = useApiMutation<Library, FormValues>(
+    (values) => ({
       path: '/libraries',
-      init: { method: 'POST', body: JSON.stringify(body) },
+      init: {
+        method: 'POST',
+        body: JSON.stringify({ platformId: values.platformId, path: values.rootPath }),
+      },
+    }),
+    {
+      onMutate: async (values) => {
+        await queryClient.cancelQueries({ queryKey: ['libraries'] });
+        const previous = queryClient.getQueryData<Library[]>(['libraries']);
+        const optimistic: Library = {
+          id: `temp-${Math.random()}`,
+          platformId: values.platformId,
+          path: values.rootPath,
+          lastScannedAt: null,
+        };
+        queryClient.setQueryData<Library[]>(['libraries'], (old) =>
+          old ? [...old, optimistic] : [optimistic],
+        );
+        return { previous };
+      },
+      onError: (_err, _vars, ctx) => {
+        queryClient.setQueryData(['libraries'], ctx?.previous);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      },
+      onSuccess: () => {
+        setOpen(false);
+      },
+    },
+  );
+
+  const updateMutation = useApiMutation<Library, { id: string; values: FormValues }>(
+    ({ id, values }) => ({
+      path: `/libraries/${id}`,
+      init: {
+        method: 'PUT',
+        body: JSON.stringify({ platformId: values.platformId, path: values.rootPath }),
+      },
     }),
     {
       onSuccess: () => {
-        setPath('');
-        setPlatformId('');
+        setOpen(false);
         queryClient.invalidateQueries({ queryKey: ['libraries'] });
       },
     },
   );
 
-  const scanMutation = useApiMutation<any, string>((id) => ({
-    path: `/libraries/${id}/scan`,
-    init: { method: 'POST', body: JSON.stringify({}) },
-  }));
+  const deleteMutation = useApiMutation<void, string>(
+    (id) => ({ path: `/libraries/${id}`, init: { method: 'DELETE' } }),
+    {
+      onMutate: async (id) => {
+        await queryClient.cancelQueries({ queryKey: ['libraries'] });
+        const previous = queryClient.getQueryData<Library[]>(['libraries']);
+        queryClient.setQueryData<Library[]>(['libraries'], (old) =>
+          old?.filter((l) => l.id !== id) ?? [],
+        );
+        return { previous };
+      },
+      onError: (_err, _vars, ctx) => {
+        queryClient.setQueryData(['libraries'], ctx?.previous);
+      },
+      onSettled: () => {
+        queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      },
+    },
+  );
+
+  const scanMutation = useApiMutation<void, string>(
+    (id) => ({
+      path: `/libraries/${id}/scan`,
+      init: { method: 'POST', body: JSON.stringify({}) },
+    }),
+    {
+      onSuccess: () => {
+        toast('Scan started');
+        queryClient.invalidateQueries({ queryKey: ['libraries'] });
+      },
+    },
+  );
+
+  const onSubmit = (values: FormValues) => {
+    if (editing) {
+      updateMutation.mutate({ id: editing.id, values });
+    } else {
+      createMutation.mutate(values);
+    }
+  };
+
+  const handleAdd = () => {
+    setEditing(null);
+    setOpen(true);
+  };
+
+  const handleEdit = (lib: Library) => {
+    setEditing(lib);
+    setOpen(true);
+  };
 
   return (
-    <div className="p-4">
-      <h1 className="text-xl mb-4">Libraries</h1>
-      <ul className="mb-4 space-y-2">
-        {data?.map((lib: any) => (
-          <li key={lib.id} className="flex items-center gap-2">
-            <span className="flex-1">{lib.path}</span>
-            <Button onClick={() => scanMutation.mutate(lib.id)}>Scan</Button>
-          </li>
-        ))}
-      </ul>
-      <div className="flex gap-2">
-        <Input
-          placeholder="Path"
-          value={path}
-          onChange={(e) => setPath(e.target.value)}
-        />
-        <Input
-          placeholder="Platform"
-          value={platformId}
-          onChange={(e) => setPlatformId(e.target.value)}
-        />
-        <Button onClick={() => addMutation.mutate()} disabled={!path || !platformId}>
-          Add
-        </Button>
+    <div className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl">Libraries</h1>
+        <Button onClick={handleAdd}>Add Library</Button>
       </div>
+
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="border-b text-left">
+            <th className="px-2 py-1">Platform</th>
+            <th className="px-2 py-1">Path</th>
+            <th className="px-2 py-1">Last Scanned</th>
+            <th className="px-2 py-1">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((lib) => (
+            <tr key={lib.id} className="border-b">
+              <td className="px-2 py-1">{lib.platformId}</td>
+              <td className="px-2 py-1 break-all">{lib.path}</td>
+              <td className="px-2 py-1">
+                {lib.lastScannedAt ? new Date(lib.lastScannedAt).toLocaleString() : '-'}
+              </td>
+              <td className="px-2 py-1 space-x-2">
+                <Button className="h-8 px-2" onClick={() => scanMutation.mutate(lib.id)}>
+                  Scan
+                </Button>
+                <Button
+                  className="h-8 px-2"
+                  variant="ghost"
+                  onClick={() => handleEdit(lib)}
+                >
+                  Edit
+                </Button>
+                <Button
+                  className="h-8 px-2"
+                  variant="ghost"
+                  onClick={() => deleteMutation.mutate(lib.id)}
+                >
+                  Delete
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-80 space-y-4 rounded bg-white p-4 dark:bg-gray-900">
+            <h2 className="text-lg">
+              {editing ? 'Edit Library' : 'Add Library'}
+            </h2>
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-3">
+              <div>
+                <label className="mb-1 block text-sm">Platform ID</label>
+                <Input {...form.register('platformId')} />
+                {form.formState.errors.platformId && (
+                  <p className="text-sm text-red-500">
+                    {form.formState.errors.platformId.message}
+                  </p>
+                )}
+              </div>
+              <div>
+                <label className="mb-1 block text-sm">Root Path</label>
+                <Input {...form.register('rootPath')} />
+                {form.formState.errors.rootPath && (
+                  <p className="text-sm text-red-500">
+                    {form.formState.errors.rootPath.message}
+                  </p>
+                )}
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setOpen(false)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={createMutation.isPending || updateMutation.isPending}
+                >
+                  {editing ? 'Save' : 'Add'}
+                </Button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^3.3.4
+        version: 3.10.0(react-hook-form@7.62.0(react@18.3.1))
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.16
         version: 2.1.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -99,12 +102,18 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.51.3
+        version: 7.62.0(react@18.3.1)
       react-router-dom:
         specifier: ^6.23.0
         version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
@@ -676,6 +685,11 @@ packages:
 
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@hutson/parse-repository-url@5.0.0':
     resolution: {integrity: sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==}
@@ -2399,6 +2413,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.62.0:
+    resolution: {integrity: sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
@@ -3383,6 +3403,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.10': {}
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.62.0(react@18.3.1))':
+    dependencies:
+      react-hook-form: 7.62.0(react@18.3.1)
 
   '@hutson/parse-repository-url@5.0.0': {}
 
@@ -5011,6 +5035,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.62.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary
- add dependencies for forms and validation
- build libraries page with table and modal form
- enable scan with toast and optimistic library create/delete

## Testing
- `pnpm -w lint`
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f1eb7e148330920e83dfa84c2db1