### PR TITLE
feat(web): improve unmatched matching

### DIFF
--- a/apps/web/src/pages/Unmatched.tsx
+++ b/apps/web/src/pages/Unmatched.tsx
@@ -1,65 +1,178 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useApiQuery, useApiMutation } from '../lib/api';
 import { Button } from '../components/ui/button';
+import { Input } from '../components/ui/input';
+
+interface Artifact {
+  id: string;
+  path: string;
+  size: number;
+  crc32?: string | null;
+  sha1?: string | null;
+  addedAt?: string;
+}
+
+interface SearchResult {
+  id: string;
+  title: string;
+  year?: number;
+  coverUrl?: string;
+  sources: string[];
+}
 
 export function Unmatched() {
   const queryClient = useQueryClient();
-  const { data } = useApiQuery<any[]>({
-    queryKey: ['unmatched'],
-    path: '/artifacts/unmatched',
-  });
-  const [selected, setSelected] = useState<any | null>(null);
-  const searchQuery = useApiQuery<any[]>({
-    queryKey: ['search', selected?.id],
-    path: `/metadata/search?q=${encodeURIComponent(
-      selected?.path.split('/').pop() || '',
-    )}&platform=`,
-    enabled: !!selected,
+  const [page, setPage] = useState(1);
+  const limit = 20;
+  const { data } = useApiQuery<Artifact[]>({
+    queryKey: ['unmatched', page],
+    path: `/artifacts/unmatched?page=${page}&limit=${limit}`,
   });
 
-  const matchMutation = useApiMutation<void, string>(
-    (providerId) => ({
+  const [selected, setSelected] = useState<Artifact | null>(null);
+  const [query, setQuery] = useState('');
+  const [platform, setPlatform] = useState('');
+  const [searchParams, setSearchParams] = useState<{ q: string; platform: string } | null>(null);
+
+  useEffect(() => {
+    if (selected) {
+      const defaultQuery = selected.path.split('/').pop() || '';
+      setQuery(defaultQuery);
+      setPlatform('');
+      setSearchParams({ q: defaultQuery, platform: '' });
+    }
+  }, [selected]);
+
+  const searchQuery = useApiQuery<SearchResult[]>({
+    queryKey: ['search', searchParams?.q, searchParams?.platform],
+    path: `/metadata/search?q=${encodeURIComponent(searchParams?.q || '')}&platform=${encodeURIComponent(
+      searchParams?.platform || '',
+    )}`,
+    enabled: !!selected && !!searchParams?.q,
+  });
+
+  const matchMutation = useApiMutation<void, { provider: string; providerId: string }>(
+    ({ provider, providerId }) => ({
       path: `/artifacts/${selected!.id}/match`,
       init: {
         method: 'POST',
-        body: JSON.stringify({ provider: 'rawg', providerId }),
+        body: JSON.stringify({ provider, providerId }),
       },
     }),
     {
       onSuccess: () => {
+        toast('Match approved');
         setSelected(null);
         queryClient.invalidateQueries({ queryKey: ['unmatched'] });
       },
+      onError: (err) => toast.error(err.message),
     },
   );
 
   return (
     <div className="flex">
-      <table className="flex-1">
-        <tbody>
-          {data?.map((a: any) => (
-            <tr
-              key={a.id}
-              onClick={() => setSelected(a)}
-              className="cursor-pointer"
-            >
-              <td className="p-2 border-b">{a.path}</td>
+      <div className="flex-1">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="text-left border-b">
+              <th className="p-2">Path</th>
+              <th className="p-2">Size</th>
+              <th className="p-2">Hashes</th>
+              <th className="p-2">Added</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-      {selected && (
-        <div className="w-80 border-l p-4 space-y-2">
-          <h2 className="font-bold break-all">{selected.path}</h2>
-          <ul className="space-y-2">
-            {searchQuery.data?.map((r: any) => (
-              <li key={r.id} className="flex items-center gap-2">
-                <span className="flex-1">{r.title}</span>
-                <Button onClick={() => matchMutation.mutate(r.id)}>Approve</Button>
-              </li>
+          </thead>
+          <tbody>
+            {data?.map((a) => (
+              <tr
+                key={a.id}
+                onClick={() => setSelected(a)}
+                className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-900"
+              >
+                <td className="p-2 border-b break-all">{a.path}</td>
+                <td className="p-2 border-b">{a.size}</td>
+                <td className="p-2 border-b">
+                  {[a.crc32, a.sha1].filter(Boolean).join(' / ')}
+                </td>
+                <td className="p-2 border-b">
+                  {a.addedAt ? new Date(a.addedAt).toLocaleString() : ''}
+                </td>
+              </tr>
             ))}
-          </ul>
+          </tbody>
+        </table>
+        <div className="flex items-center justify-between p-2">
+          <Button
+            variant="ghost"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={page === 1}
+          >
+            Previous
+          </Button>
+          <span>Page {page}</span>
+          <Button
+            variant="ghost"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!data || data.length < limit}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
+
+      {selected && (
+        <div className="w-80 border-l p-4 space-y-4">
+          <h2 className="font-bold break-all">{selected.path}</h2>
+          <form
+            className="flex gap-2"
+            onSubmit={(e) => {
+              e.preventDefault();
+              setSearchParams({ q: query, platform });
+            }}
+          >
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Title"
+              className="flex-1"
+            />
+            <Input
+              value={platform}
+              onChange={(e) => setPlatform(e.target.value)}
+              placeholder="Platform"
+              className="w-24"
+            />
+            <Button type="submit">Search</Button>
+          </form>
+
+          <div className="grid gap-2">
+            {searchQuery.data?.map((r) => (
+              <div key={r.id} className="border rounded overflow-hidden">
+                {r.coverUrl && (
+                  <img
+                    src={r.coverUrl}
+                    alt={r.title}
+                    className="h-40 w-full object-cover"
+                  />
+                )}
+                <div className="p-2 space-y-1">
+                  <div className="font-medium leading-tight">{r.title}</div>
+                  <div className="text-xs text-gray-500">
+                    {[r.year, r.sources.join(', ')].filter(Boolean).join(' • ')}
+                  </div>
+                  <Button
+                    className="w-full"
+                    onClick={() =>
+                      matchMutation.mutate({ provider: r.sources[0], providerId: r.id })
+                    }
+                  >
+                    Approve
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- add paginated unmatched artifact table with details
- support searching metadata and approving matches with toasts

## Testing
- `pnpm lint`
- `pnpm test` (fails: command exited with code 1)
- `pnpm --filter @gamearr/web test`


------
https://chatgpt.com/codex/tasks/task_e_68b0f80588e88330ac6c65fecebe9216