### PR TITLE
feat: add downloads management

### DIFF
--- a/apps/api/src/downloads/downloads.controller.ts
+++ b/apps/api/src/downloads/downloads.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { Body, Controller, Post, Get, Param, Delete } from '@nestjs/common';
 import { DownloadsService } from './downloads.service';
 
 @Controller('downloads')
@@ -8,5 +8,25 @@ export class DownloadsController {
   @Post('magnet')
   addMagnet(@Body() body: { magnet: string }) {
     return this.service.addMagnet(body.magnet);
+  }
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Post(':hash/pause')
+  pause(@Param('hash') hash: string) {
+    return this.service.pause(hash);
+  }
+
+  @Post(':hash/resume')
+  resume(@Param('hash') hash: string) {
+    return this.service.resume(hash);
+  }
+
+  @Delete(':hash')
+  remove(@Param('hash') hash: string) {
+    return this.service.remove(hash);
   }
 }

--- a/apps/api/src/downloads/downloads.controller.ts
+++ b/apps/api/src/downloads/downloads.controller.ts
@@ -1,9 +1,19 @@
-import { Body, Controller, Post, Get, Param, Delete } from '@nestjs/common';
-import { DownloadsService } from './downloads.service';
+import {
+  Body,
+  Controller,
+  Post,
+  Get,
+  Param,
+  Delete,
+  Inject,
+} from '@nestjs/common';
+import { DownloadsService } from './downloads.service.js';
 
 @Controller('downloads')
 export class DownloadsController {
-  constructor(private readonly service: DownloadsService) {}
+  constructor(
+    @Inject(DownloadsService) private readonly service: DownloadsService,
+  ) {}
 
   @Post('magnet')
   addMagnet(@Body() body: { magnet: string }) {

--- a/apps/api/src/downloads/downloads.service.ts
+++ b/apps/api/src/downloads/downloads.service.ts
@@ -6,4 +6,29 @@ export class DownloadsService {
   addMagnet(magnet: string) {
     return qbittorrent.addMagnet(magnet);
   }
+
+  async list() {
+    const torrents = await qbittorrent.getStatus();
+    return torrents.map((t) => ({
+      hash: t.hash,
+      name: t.name,
+      state: t.state,
+      progress: t.progress,
+      dlspeed: t.dlspeed,
+      eta: t.eta,
+      client: 'qbittorrent',
+    }));
+  }
+
+  pause(hash: string) {
+    return qbittorrent.pause(hash);
+  }
+
+  resume(hash: string) {
+    return qbittorrent.resume(hash);
+  }
+
+  remove(hash: string) {
+    return qbittorrent.remove(hash);
+  }
 }

--- a/apps/web/src/pages/Downloads.tsx
+++ b/apps/web/src/pages/Downloads.tsx
@@ -1,17 +1,160 @@
-import { useApiQuery } from '../lib/api';
+import { useEffect } from 'react';
+import { useApiQuery, useApiMutation } from '../lib/api';
+import { useQueryClient } from '@tanstack/react-query';
+
+interface Download {
+  hash: string;
+  name: string;
+  client: string;
+  progress: number;
+  dlspeed: number;
+  eta: number;
+  state: string;
+}
+
+function formatSpeed(bytes: number) {
+  if (!bytes) return '0 B/s';
+  const units = ['B/s', 'KB/s', 'MB/s', 'GB/s'];
+  let i = 0;
+  while (bytes >= 1024 && i < units.length - 1) {
+    bytes /= 1024;
+    i++;
+  }
+  return `${bytes.toFixed(1)} ${units[i]}`;
+}
+
+function formatEta(seconds: number) {
+  if (seconds <= 0 || !Number.isFinite(seconds)) return '—';
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = Math.floor(seconds % 60);
+  const parts = [];
+  if (h) parts.push(`${h}h`);
+  if (m) parts.push(`${m}m`);
+  if (s || parts.length === 0) parts.push(`${s}s`);
+  return parts.join(' ');
+}
 
 export function Downloads() {
-  const { data } = useApiQuery<any[]>({ queryKey: ['downloads'], path: '/downloads' });
+  const queryClient = useQueryClient();
+  const { data } = useApiQuery<Download[]>({
+    queryKey: ['downloads'],
+    path: '/downloads',
+    refetchInterval: 3000,
+  });
+
+  useEffect(() => {
+    try {
+      const base = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+      const url = new URL(base);
+      url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+      url.pathname = '/ws';
+      const ws = new WebSocket(url.toString());
+      ws.onmessage = (ev) => {
+        try {
+          const payload = JSON.parse(ev.data);
+          if (payload.type === 'downloads') {
+            queryClient.setQueryData(['downloads'], payload.data);
+          }
+        } catch {
+          // ignore
+        }
+      };
+      return () => ws.close();
+    } catch {
+      // ignore errors and fall back to polling
+    }
+  }, [queryClient]);
+
+  const pauseMut = useApiMutation<void, { hash: string }>((v) => ({
+    path: `/downloads/${v.hash}/pause`,
+    init: { method: 'POST' },
+  }), {
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['downloads'] }),
+  });
+
+  const resumeMut = useApiMutation<void, { hash: string }>((v) => ({
+    path: `/downloads/${v.hash}/resume`,
+    init: { method: 'POST' },
+  }), {
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['downloads'] }),
+  });
+
+  const removeMut = useApiMutation<void, { hash: string }>((v) => ({
+    path: `/downloads/${v.hash}`,
+    init: { method: 'DELETE' },
+  }), {
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['downloads'] }),
+  });
+
   return (
     <div className="p-4">
       <h1 className="text-xl mb-4">Downloads</h1>
-      <ul className="space-y-2">
-        {data?.map((d: any) => (
-          <li key={d.id || d.hash} className="border p-2 rounded">
-            {d.name} {d.progress ? `(${d.progress}%)` : ''}
-          </li>
-        ))}
-      </ul>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead>
+            <tr className="text-left">
+              <th className="p-2">Name</th>
+              <th className="p-2">Client</th>
+              <th className="p-2">Progress</th>
+              <th className="p-2">Speed</th>
+              <th className="p-2">ETA</th>
+              <th className="p-2">State</th>
+              <th className="p-2">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.map((d) => (
+              <tr key={d.hash} className="border-t">
+                <td className="p-2">{d.name}</td>
+                <td className="p-2">{d.client}</td>
+                <td className="p-2 w-48">
+                  <div className="w-full bg-gray-200 rounded h-2">
+                    <div
+                      className="bg-blue-500 h-2 rounded"
+                      style={{ width: `${(d.progress || 0) * 100}%` }}
+                    />
+                  </div>
+                </td>
+                <td className="p-2">{formatSpeed(d.dlspeed)}</td>
+                <td className="p-2">{formatEta(d.eta)}</td>
+                <td className="p-2">
+                  {d.state}{' '}
+                  {d.state === 'completed' && (
+                    <a href="/activity" className="text-blue-600 ml-2">
+                      Show in Imports
+                    </a>
+                  )}
+                </td>
+                <td className="p-2 space-x-2">
+                  {d.state.startsWith('paused') ? (
+                    <button
+                      className="text-blue-600"
+                      onClick={() => resumeMut.mutate({ hash: d.hash })}
+                    >
+                      Resume
+                    </button>
+                  ) : (
+                    <button
+                      className="text-blue-600"
+                      onClick={() => pauseMut.mutate({ hash: d.hash })}
+                    >
+                      Pause
+                    </button>
+                  )}
+                  <button
+                    className="text-red-600"
+                    onClick={() => removeMut.mutate({ hash: d.hash })}
+                  >
+                    Remove
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }
+

--- a/packages/adapters/src/downloads/qbittorrent.ts
+++ b/packages/adapters/src/downloads/qbittorrent.ts
@@ -56,6 +56,8 @@ export interface TorrentInfo {
   name: string;
   state: string;
   progress: number;
+  dlspeed: number;
+  eta: number;
   save_path?: string;
   content_path?: string;
 }
@@ -67,4 +69,16 @@ export async function getStatus(): Promise<TorrentInfo[]> {
     throw new Error(`qbittorrent status failed: ${res.status} ${text}`);
   }
   return res.json();
+}
+
+export async function pause(hash: string) {
+  await qbFetch(`/torrents/pause?hashes=${hash}`, { method: 'POST' });
+}
+
+export async function resume(hash: string) {
+  await qbFetch(`/torrents/resume?hashes=${hash}`, { method: 'POST' });
+}
+
+export async function remove(hash: string) {
+  await qbFetch(`/torrents/delete?hashes=${hash}&deleteFiles=false`, { method: 'POST' });
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -18,6 +18,9 @@ export const igdb = {
 export const qbittorrent = {
   addMagnet: qbittorrentModule.addMagnet,
   getStatus: qbittorrentModule.getStatus,
+  pause: qbittorrentModule.pause,
+  resume: qbittorrentModule.resume,
+  remove: qbittorrentModule.remove,
 };
 
 export const emulationstation = {


### PR DESCRIPTION
## Summary
- show current downloads with progress, speed and ETA
- allow pausing, resuming and removing downloads

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b12aac0fe48330aa8d6b2997222f36