### PR TITLE
feat: add organize settings with preview

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { DownloadsModule } from './downloads/downloads.module';
 import { ExportsModule } from './exports/exports.module';
 import { PlatformModule } from './platform/platform.module';
 import { GameModule } from './game/game.module.js';
+import { SettingsModule } from './settings/settings.module.js';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { GameModule } from './game/game.module.js';
     ExportsModule,
     PlatformModule,
     GameModule,
+    SettingsModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/imports/imports.controller.ts
+++ b/apps/api/src/imports/imports.controller.ts
@@ -10,6 +10,11 @@ export class ImportsController {
     return this.service.organize(body.artifactId, body.template, body.romsRoot);
   }
 
+  @Post('organize/preview')
+  preview(@Body() body: { artifactId: string; template: string; romsRoot?: string }) {
+    return this.service.preview(body.artifactId, body.template, body.romsRoot);
+  }
+
   @Get('activity')
   activity() {
     return this.service.activity();

--- a/apps/api/src/imports/imports.service.ts
+++ b/apps/api/src/imports/imports.service.ts
@@ -1,7 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { moveArtifact } from '@gamearr/domain';
+import { moveArtifact, renderTemplate } from '@gamearr/domain';
 import { readActivity, removeActivity } from '@gamearr/shared';
 import { PrismaService } from '../prisma/prisma.service.js';
+import path from 'node:path';
+import { BadRequestException } from '@nestjs/common';
 
 @Injectable()
 export class ImportsService {
@@ -20,6 +22,33 @@ export class ImportsService {
     }
     const path = await moveArtifact(artifact as any, template, romsRoot);
     return { path };
+  }
+
+  async preview(artifactId: string, template: string, romsRoot = '/roms') {
+    const artifact = await this.prisma.artifact.findUnique({
+      where: { id: artifactId },
+      include: {
+        library: { include: { platform: true } },
+        release: { include: { game: true } },
+      },
+    });
+    if (!artifact) {
+      throw new NotFoundException('Artifact not found');
+    }
+    const ext = path.extname(artifact.path);
+    const ctx = {
+      platform: artifact.library.platform.name,
+      game: artifact.release?.game.title ?? path.parse(artifact.path).name,
+      disc: artifact.multiPartGroup ?? '',
+      ext,
+    } as Record<string, unknown>;
+    try {
+      const name = renderTemplate(ctx, template) + ext;
+      const dest = path.join(romsRoot, artifact.library.platform.name, name);
+      return { path: dest };
+    } catch (err: any) {
+      throw new BadRequestException(err.message);
+    }
   }
 
   async activity() {

--- a/apps/api/src/imports/preview.test.ts
+++ b/apps/api/src/imports/preview.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { Test as NestTest } from '@nestjs/testing';
+import { ImportsController } from './imports.controller.js';
+import { ImportsService } from './imports.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+const artifact = {
+  id: '1',
+  path: 'Sonic.bin',
+  multiPartGroup: null,
+  library: { path: '/library', platform: { name: 'Dreamcast' } },
+  release: { game: { title: 'Sonic' } },
+};
+
+test('POST /imports/organize/preview returns path', async () => {
+  const prismaStub = {
+    artifact: {
+      findUnique: async () => artifact,
+    },
+  };
+
+  const moduleRef = await NestTest.createTestingModule({
+    controllers: [ImportsController],
+    providers: [ImportsService, { provide: PrismaService, useValue: prismaStub }],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+
+  const template = '${game}${disc? ` (Disc ${disc})`:``}';
+  const res = await fetch(`http://localhost:${port}/imports/organize/preview`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ artifactId: '1', template, romsRoot: '/roms' }),
+  });
+  const json = await res.json();
+  assert.equal(json.path, path.join('/roms', 'Dreamcast/Sonic.bin'));
+  await app.close();
+});
+

--- a/apps/api/src/settings/settings.controller.ts
+++ b/apps/api/src/settings/settings.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Put, Body, Inject } from '@nestjs/common';
+import { SettingsService } from './settings.service.js';
+
+@Controller('settings')
+export class SettingsController {
+  constructor(@Inject(SettingsService) private readonly service: SettingsService) {}
+
+  @Get('organize')
+  getOrganize() {
+    return this.service.getOrganize();
+  }
+
+  @Put('organize')
+  setOrganize(@Body() body: { template: string }) {
+    return this.service.setOrganize(body.template);
+  }
+}
+

--- a/apps/api/src/settings/settings.module.ts
+++ b/apps/api/src/settings/settings.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { SettingsController } from './settings.controller.js';
+import { SettingsService } from './settings.service.js';
+
+@Module({
+  controllers: [SettingsController],
+  providers: [SettingsService],
+})
+export class SettingsModule {}
+

--- a/apps/api/src/settings/settings.service.ts
+++ b/apps/api/src/settings/settings.service.ts
@@ -1,0 +1,24 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { readSettings, writeSettings } from '@gamearr/shared';
+import { renderTemplate } from '@gamearr/domain';
+
+@Injectable()
+export class SettingsService {
+  async getOrganize() {
+    const settings = await readSettings();
+    return { template: settings.organizeTemplate };
+  }
+
+  async setOrganize(template: string) {
+    try {
+      renderTemplate({ game: 'Game', platform: 'Platform', disc: '', ext: '.bin' }, template);
+    } catch (err: any) {
+      throw new BadRequestException(err.message);
+    }
+    const settings = await readSettings();
+    const updated = { ...settings, organizeTemplate: template };
+    await writeSettings(updated);
+    return { template };
+  }
+}
+

--- a/apps/api/src/settings/settings.test.ts
+++ b/apps/api/src/settings/settings.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+const NestTest = await import('@nestjs/testing');
+
+const setup = async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'settings-'));
+  process.env.DOWNLOADS_ROOT = tmp;
+  const { SettingsController } = await import('./settings.controller.js');
+  const { SettingsService } = await import('./settings.service.js');
+  const moduleRef = await NestTest.Test.createTestingModule({
+    controllers: [SettingsController],
+    providers: [SettingsService],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+  return { tmp, app, port };
+};
+
+test('PUT /settings/organize saves template', async () => {
+  const { tmp, app, port } = await setup();
+  const res = await fetch(`http://localhost:${port}/settings/organize`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ template: '${game}' }),
+  });
+  const json = await res.json();
+  assert.equal(json.template, '${game}');
+  const file = await fs.readFile(path.join(tmp, 'settings.json'), 'utf8');
+  const parsed = JSON.parse(file);
+  assert.equal(parsed.organizeTemplate, '${game}');
+  await app.close();
+});
+
+test('PUT /settings/organize validates template', async () => {
+  const { app, port } = await setup();
+  const res = await fetch(`http://localhost:${port}/settings/organize`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ template: '${' }),
+  });
+  assert.equal(res.status, 400);
+  await app.close();
+});
+

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { Games } from '../pages/Games';
 import { Activity } from '../pages/Activity';
 import { Downloads } from '../pages/Downloads';
 import { Settings } from '../pages/Settings';
+import { SettingsOrganize } from '../pages/SettingsOrganize';
 import { Input } from '../components/ui/input';
 import { Button } from '../components/ui/button';
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '../components/ui/dropdown-menu';
@@ -104,6 +105,7 @@ export function Layout() {
             <Route path="/activity" element={<Activity />} />
             <Route path="/downloads" element={<Downloads />} />
             <Route path="/settings" element={<Settings />} />
+            <Route path="/settings/organize" element={<SettingsOrganize />} />
             <Route path="*" element={<Navigate to="/libraries" replace />} />
           </Routes>
         </main>

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useApiQuery } from '../lib/api';
 import { Input } from '../components/ui/input';
 
@@ -16,6 +17,11 @@ export function Settings() {
 
   return (
     <div className="p-4 space-y-4">
+      <div>
+        <Link to="/settings/organize" className="text-blue-500 underline">
+          Organize Settings
+        </Link>
+      </div>
       <div>API health: {data ? 'ok' : '...'}</div>
       <div>
         <label className="block mb-1">Region Priority</label>

--- a/apps/web/src/pages/SettingsOrganize.tsx
+++ b/apps/web/src/pages/SettingsOrganize.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { apiFetch, ApiError, useApiQuery, useApiMutation } from '../lib/api';
+
+export function SettingsOrganize() {
+  const [template, setTemplate] = useState('');
+  const [artifactId, setArtifactId] = useState('');
+
+  const { data: settings } = useApiQuery<{ template: string }>({
+    queryKey: ['settings-organize'],
+    path: '/settings/organize',
+  });
+
+  useEffect(() => {
+    if (settings?.template) {
+      setTemplate(settings.template);
+    }
+  }, [settings]);
+
+  const { data: artifacts } = useApiQuery<any[]>({
+    queryKey: ['artifacts-unmatched'],
+    path: '/artifacts/unmatched',
+  });
+
+  const previewQuery = useQuery<{ path: string }, ApiError>({
+    queryKey: ['organize-preview', artifactId, template],
+    queryFn: () =>
+      apiFetch('/imports/organize/preview', {
+        method: 'POST',
+        body: JSON.stringify({ artifactId, template }),
+      }),
+    enabled: !!artifactId && !!template,
+  });
+
+  const saveMutation = useApiMutation<{ template: string }, { template: string }>(
+    (vars) => ({
+      path: '/settings/organize',
+      init: { method: 'PUT', body: JSON.stringify({ template: vars.template }) },
+    }),
+  );
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block mb-1">Rename Template</label>
+        <textarea
+          className="w-full border rounded p-2 h-32"
+          value={template}
+          onChange={(e) => setTemplate(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Sample Artifact</label>
+        <select
+          className="border rounded p-2 w-full"
+          value={artifactId}
+          onChange={(e) => setArtifactId(e.target.value)}
+        >
+          <option value="">Select artifact</option>
+          {artifacts?.map((a) => (
+            <option key={a.id} value={a.id}>
+              {a.path}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="p-2 border rounded min-h-[2rem]">
+        {previewQuery.data?.path}
+        {previewQuery.error && <div className="text-red-600">{previewQuery.error.message}</div>}
+      </div>
+      <div>
+        <button
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+          onClick={() => saveMutation.mutate({ template })}
+        >
+          Save
+        </button>
+        {saveMutation.error && (
+          <div className="text-red-600 mt-1">{saveMutation.error.message}</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SettingsOrganize;
+

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
 export * from './config.js';
 export * from './logger.js';
 export * from './activity.js';
+export * from './settings.js';

--- a/packages/shared/src/settings.ts
+++ b/packages/shared/src/settings.ts
@@ -1,0 +1,30 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { z } from 'zod';
+import { config } from './config.js';
+
+const settingsSchema = z.object({
+  organizeTemplate: z.string().default('${game}${disc? ` (Disc ${disc})`:``}'),
+});
+
+export type Settings = z.infer<typeof settingsSchema>;
+
+function settingsPath() {
+  const root = config.paths.downloadsRoot || '.';
+  return path.join(root, 'settings.json');
+}
+
+export async function readSettings(): Promise<Settings> {
+  try {
+    const raw = await fs.readFile(settingsPath(), 'utf8');
+    const json = JSON.parse(raw);
+    return settingsSchema.parse(json);
+  } catch {
+    return settingsSchema.parse({});
+  }
+}
+
+export async function writeSettings(settings: Settings) {
+  await fs.writeFile(settingsPath(), JSON.stringify(settings, null, 2));
+}
+


### PR DESCRIPTION
## Summary
- add `/settings/organize` page with template editor and live preview
- store organize template via new settings API and preview endpoint
- include tests for settings persistence and organize preview

## Testing
- `pnpm lint`
- `node --test apps/api/dist/apps/api/src/imports/preview.test.js apps/api/dist/apps/api/src/settings/settings.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b13255090483308547a0380ceacf36