### PR TITLE
ci: update trivy action to 0.33.0

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -91,7 +91,7 @@ jobs:
           image: ${{ steps.meta.outputs.tags }}
           output-file: sbom-${{ matrix.app }}.spdx.json
       - name: Trivy scan
-        uses: aquasecurity/trivy-action@v0.11.2
+        uses: aquasecurity/trivy-action@0.33.0
         with:
           image-ref: ${{ steps.meta.outputs.tags }}
       - uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
## Summary
- use latest aquasecurity/trivy-action 0.33.0 in containers workflow

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b136af6ab483308cd44ac19d6a56f4