### PR TITLE
feat: manage duplicate games with 1G1R

### DIFF
--- a/apps/api/src/exports/exports.service.ts
+++ b/apps/api/src/exports/exports.service.ts
@@ -51,7 +51,7 @@ export class ExportsService {
 
   private async computeItemCount(): Promise<number> {
     return this.prisma.artifact.count({
-      where: { releaseId: { not: null } },
+      where: { releaseId: { not: null }, preferred: true } as any,
     });
   }
 

--- a/apps/api/src/game/game.controller.ts
+++ b/apps/api/src/game/game.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Inject } from '@nestjs/common';
+import { Controller, Get, Query, Inject, Post, Body } from '@nestjs/common';
 import { GameService } from './game.service.js';
 
 @Controller('games')
@@ -22,6 +22,16 @@ export class GameController {
       yearEnd: yearEnd ? parseInt(yearEnd, 10) : undefined,
       q,
     });
+  }
+
+  @Get('duplicates')
+  duplicates() {
+    return this.service.findDuplicates();
+  }
+
+  @Post('duplicates/apply')
+  applyDuplicates(@Body() body: { overrides?: Record<string, string>; dryRun?: boolean }) {
+    return this.service.applyOneGameOneRom(body.overrides ?? {}, body.dryRun ?? true);
   }
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Folder, FileQuestion, Gamepad2, Activity as ActivityIcon, Download, Set
 import { Libraries } from '../pages/Libraries';
 import { Unmatched } from '../pages/Unmatched';
 import { Games } from '../pages/Games';
+import { GamesDuplicates } from '../pages/GamesDuplicates';
 import { Activity } from '../pages/Activity';
 import { Downloads } from '../pages/Downloads';
 import { Settings } from '../pages/Settings';
@@ -103,6 +104,7 @@ export function Layout() {
             <Route path="/libraries" element={<Libraries />} />
             <Route path="/unmatched" element={<Unmatched />} />
             <Route path="/games" element={<Games />} />
+            <Route path="/games/duplicates" element={<GamesDuplicates />} />
             <Route path="/activity" element={<Activity />} />
             <Route path="/downloads" element={<Downloads />} />
             <Route path="/settings" element={<Settings />} />

--- a/apps/web/src/pages/GamesDuplicates.tsx
+++ b/apps/web/src/pages/GamesDuplicates.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { useApiQuery, useApiMutation } from '../lib/api';
+import { Button } from '../components/ui/button';
+
+interface ArtifactInfo {
+  id: string;
+  preferred: boolean;
+  region?: string;
+  revision?: number;
+  verified?: boolean;
+}
+
+interface DuplicateGame {
+  id: string;
+  title: string;
+  artifacts: ArtifactInfo[];
+}
+
+export function GamesDuplicates() {
+  const { data, refetch } = useApiQuery<DuplicateGame[]>({
+    queryKey: ['game-duplicates'],
+    path: '/games/duplicates',
+  });
+  const [overrides, setOverrides] = useState<Record<string, string | undefined>>({});
+
+  const mutation = useApiMutation<{ changes: { artifactId: string; preferred: boolean }[] }, { dryRun: boolean; overrides: Record<string, string> }>(
+    ({ dryRun, overrides }) => ({
+      path: '/games/duplicates/apply',
+      init: {
+        method: 'POST',
+        body: JSON.stringify({ dryRun, overrides }),
+      },
+    }),
+  );
+
+  function artifactLabel(a: ArtifactInfo) {
+    const parts = [] as string[];
+    if (a.region) parts.push(a.region);
+    if (a.revision != null) parts.push(`rev ${a.revision}`);
+    if (a.verified) parts.push('verified');
+    return parts.join(' ');
+  }
+
+  async function apply() {
+    const preview = await mutation.mutateAsync({ dryRun: true, overrides });
+    const summary = preview.changes
+      .map((c) => `${c.artifactId}: ${c.preferred ? 'preferred' : 'not preferred'}`)
+      .join('\n');
+    const ok = window.confirm(`Apply the following changes?\n${summary}`);
+    if (!ok) return;
+    await mutation.mutateAsync({ dryRun: false, overrides });
+    setOverrides({});
+    refetch();
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl">Duplicate Games</h1>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Game</th>
+            <th className="text-left p-2">Preferred</th>
+            <th className="text-left p-2">Candidates</th>
+            <th className="text-left p-2">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((g) => {
+            const prefId =
+              overrides[g.id] || g.artifacts.find((a) => a.preferred)?.id || g.artifacts[0]?.id || '';
+            return (
+              <tr key={g.id} className="border-t">
+                <td className="p-2">{g.title}</td>
+                <td className="p-2">{artifactLabel(g.artifacts.find((a) => a.id === prefId)!)}</td>
+                <td className="p-2">
+                  {g.artifacts.map((a) => (
+                    <span key={a.id} className="mr-2">
+                      {artifactLabel(a)}
+                    </span>
+                  ))}
+                </td>
+                <td className="p-2">
+                  <select
+                    value={overrides[g.id] || ''}
+                    onChange={(e) =>
+                      setOverrides((o) => ({ ...o, [g.id]: e.target.value || undefined }))
+                    }
+                  >
+                    <option value="">Auto</option>
+                    {g.artifacts.map((a) => (
+                      <option key={a.id} value={a.id}>
+                        {artifactLabel(a)}
+                      </option>
+                    ))}
+                  </select>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+      {data && data.length > 0 && (
+        <Button onClick={apply}>Apply 1G1R</Button>
+      )}
+    </div>
+  );
+}

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -39,6 +39,7 @@ model Artifact {
   multiPartGroup String? @map("multi_part_group")
   releaseId String?
   release   Release? @relation(fields: [releaseId], references: [id])
+  preferred Boolean @default(false)
 
   @@unique([libraryId, path])
 }


### PR DESCRIPTION
## Summary
- add preferred flag to artifacts for 1G1R
- expose API to list and apply duplicate game winners
- add web page to preview/apply 1G1R and overrides

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1425652c083309a894636093c5e7d