### PR TITLE
fix: pass single tag to sbom action

### DIFF
--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ steps.meta.outputs.tags }}
+          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           output-file: sbom-${{ matrix.app }}.spdx.json
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.33.0


### PR DESCRIPTION
## Summary
- pass only the first image tag to the SBOM generation step to avoid multi-line parsing errors

## Testing
- `pnpm lint`
- `pnpm test` *(fails: command exited with code 1)*


------
https://chatgpt.com/codex/tasks/task_e_68b2069f3a2083309d7b5571b7fa8675