### PR TITLE
fix: use single tag for Trivy scan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,6 @@ jobs:
             ghcr.io/${{ github.repository }}-${{ matrix.app }}
             docker.io/${{ secrets.DOCKERHUB_USERNAME }}/gamearr-${{ matrix.app }}
           tags: |
-            type=ref,event=tag
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -90,12 +89,12 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          image: ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.meta.outputs.version }}
           output-file: sbom-${{ matrix.app }}.spdx.json
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.33.0
         with:
-          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
+          image-ref: ghcr.io/${{ github.repository }}-${{ matrix.app }}:${{ steps.meta.outputs.version }}
       - uses: sigstore/cosign-installer@v3
       - name: Sign image
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.33.0
         with:
-          image-ref: ${{ steps.meta.outputs.tags }}
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
       - uses: sigstore/cosign-installer@v3
       - name: Sign image
         env:


### PR DESCRIPTION
## Summary
- ensure release workflow passes a single image reference to Trivy

## Testing
- `pnpm test` (fails: Couldn't find configuration for either precaching or runtime caching)
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b23b966d1883308499c9098d6233aa