### PR TITLE
Fix cosign sign step for multiple tags in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Sign image
         env:
           COSIGN_YES: 'true'
-        run: cosign sign ${{ steps.meta.outputs.tags }}
+        run: echo "${{ steps.meta.outputs.tags }}" | xargs -n1 cosign sign
       - name: Generate provenance
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
## Summary
- fix release workflow cosign sign step to handle multiple image tags correctly

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Cannot find module 'rxjs' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68b23f85a35c8330815eda1e7ec5611c