### PR TITLE
fix: use tabs for Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,32 +50,32 @@ dev:
 
 .PHONY: build
 build:
-        pnpm -w build
+	pnpm -w build
 
 .PHONY: test
 test:
-        pnpm -w test
+	pnpm -w test
 
 # Release commands
 .PHONY: changelog
 changelog:
-        pnpm changeset version
-        pnpm install
-        npx conventional-changelog-cli -p angular -i CHANGELOG.md -s
+	pnpm changeset version
+	pnpm install
+	npx conventional-changelog-cli -p angular -i CHANGELOG.md -s
 
 # Help command
 .PHONY: help
 help:
-        @echo "Available commands:"
-	@echo "  docker-up      - Start all containers"
-	@echo "  docker-down    - Stop all containers"
-	@echo "  docker-restart - Restart all containers"
-	@echo "  docker-logs    - View container logs"
-	@echo "  docker-ps      - List running containers"
-	@echo "  db-migrate     - Run database migrations"
-	@echo "  db-studio      - Open Prisma Studio"
-	@echo "  dev            - Start development servers"
-        @echo "  build          - Build the project"
-        @echo "  test           - Run project tests"
-        @echo "  changelog      - Apply versions and regenerate changelog"
-        @echo "  help           - Show this help message"
+	@echo "Available commands:"
+	@echo "	 docker-up	- Start all containers"
+	@echo "	 docker-down	- Stop all containers"
+	@echo "	 docker-restart - Restart all containers"
+	@echo "	 docker-logs	- View container logs"
+	@echo "	 docker-ps	- List running containers"
+	@echo "	 db-migrate	- Run database migrations"
+	@echo "	 db-studio	- Open Prisma Studio"
+	@echo "	 dev		- Start development servers"
+	@echo "	 build		- Build the project"
+	@echo "	 test		- Run project tests"
+	@echo "	 changelog	- Apply versions and regenerate changelog"
+	@echo "	 help		- Show this help message"


### PR DESCRIPTION
## Summary
- fix Makefile commands by replacing leading spaces with tabs

## Testing
- `make build` (fails: no output files found for task @gamearr/storage#build)
- `make test` (fails: no output files found for task @gamearr/adapters#test and others)


------
https://chatgpt.com/codex/tasks/task_e_68b27f031fec83309ab86c86107fac65