### PR TITLE
feat: add dat root configuration

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,7 +2,8 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import pinoHttp from 'pino-http';
 import type { Request, Response, NextFunction } from 'express';
-import { logger, withCorrelationId } from '@gamearr/shared';
+import { mkdirSync } from 'node:fs';
+import { config, logger, withCorrelationId } from '@gamearr/shared';
 
 async function bootstrap() {
   // In ESM, static imports are hoisted and executed before this module body.
@@ -10,6 +11,9 @@ async function bootstrap() {
   // and its decorators are evaluated.
   const { AppModule } = await import('./app.module');
   const app = await NestFactory.create(AppModule);
+
+  mkdirSync(config.paths.datRoot, { recursive: true });
+  logger.info({ datRoot: config.paths.datRoot }, 'using dat root');
 
   app.enableCors({
     origin: process.env.FRONTEND_URL || 'http://localhost:5173',

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -1,4 +1,5 @@
 import { Queue, Worker } from 'bullmq';
+import { mkdirSync } from 'node:fs';
 import { config, logger, withCorrelationId } from '@gamearr/shared';
 import { scanProcessor } from './processors/scan';
 import { hashProcessor } from './processors/hash';
@@ -12,6 +13,9 @@ if (!config.redisUrl) {
   logger.warn('REDIS_URL is not set, worker disabled');
   process.exit(0);
 }
+
+mkdirSync(config.paths.datRoot, { recursive: true });
+logger.info({ datRoot: config.paths.datRoot }, 'using dat root');
 
 const connection = { connection: { url: config.redisUrl } };
 

--- a/packages/shared/src/config.test.ts
+++ b/packages/shared/src/config.test.ts
@@ -1,5 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { join } from 'node:path';
 
 const VALID_ENV = {
   DB_URL: 'postgresql://user:pass@localhost:5432/db',
@@ -9,6 +10,7 @@ const VALID_ENV = {
   IGDB_CLIENT_SECRET: 'client-secret',
   LIB_ROOT: '/library',
   DOWNLOADS_ROOT: '/downloads',
+  DATA_ROOT: '/data',
 };
 
 const loadConfig = async () => import(`./config.js?${Date.now()}`);
@@ -22,6 +24,8 @@ test('parses configuration from env', async () => {
   setEnv(VALID_ENV);
   const mod = await loadConfig();
   assert.equal(mod.config.dbUrl, VALID_ENV.DB_URL);
+  assert.equal(mod.config.paths.datRoot, join('/data', 'dats'));
+  assert.equal(mod.config.paths.platformDatDir('nes'), join('/data', 'dats', 'nes'));
   process.env = original;
 });
 

--- a/packages/shared/src/config.ts
+++ b/packages/shared/src/config.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { createRequire } from 'node:module';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { readFileSync } from 'node:fs';
 
@@ -32,12 +32,15 @@ const envSchema = z.object({
   IGDB_CLIENT_SECRET: z.string().optional(),
   LIB_ROOT: z.string().optional(),
   DOWNLOADS_ROOT: z.string().optional(),
+  DATA_ROOT: z.string().min(1),
   QBITTORRENT_URL: z.string().url().optional(),
   QBITTORRENT_USERNAME: z.string().optional(),
   QBITTORRENT_PASSWORD: z.string().optional(),
 });
 
 const env = envSchema.parse(process.env);
+
+const datRoot = join(env.DATA_ROOT, 'dats');
 
 export const config = {
   dbUrl: env.DB_URL,
@@ -50,6 +53,8 @@ export const config = {
   paths: {
     libRoot: env.LIB_ROOT,
     downloadsRoot: env.DOWNLOADS_ROOT,
+    datRoot,
+    platformDatDir: (platformId: string) => join(datRoot, platformId),
   },
   qbittorrent: {
     url: env.QBITTORRENT_URL || 'http://localhost:8080',


### PR DESCRIPTION
## Summary
- require DATA_ROOT env var and expose dat path helpers
- ensure dat root directory exists on API/Worker startup

## Testing
- `pnpm --filter @gamearr/shared lint`
- `pnpm --filter @gamearr/api lint`
- `pnpm --filter @gamearr/worker lint`
- `pnpm --filter @gamearr/shared test`
- `pnpm --filter @gamearr/api test`
- `pnpm --filter @gamearr/worker test`


------
https://chatgpt.com/codex/tasks/task_e_68b286d34c588330bc24d44649bd2f96