### PR TITLE
feat(storage): add DatFile model and active relation

### DIFF
--- a/packages/storage/prisma/migrations/20250916000000_add_dat_file/migration.sql
+++ b/packages/storage/prisma/migrations/20250916000000_add_dat_file/migration.sql
@@ -1,0 +1,31 @@
+-- AlterTable
+ALTER TABLE "Platform" ADD COLUMN     "activeDatFileId" TEXT;
+
+-- CreateTable
+CREATE TABLE "DatFile" (
+    "id" TEXT NOT NULL,
+    "platformId" TEXT NOT NULL,
+    "filename" TEXT NOT NULL,
+    "path" TEXT NOT NULL,
+    "size" BIGINT NOT NULL,
+    "sha256" TEXT NOT NULL,
+    "source" TEXT,
+    "version" TEXT,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "activatedAt" TIMESTAMP(3),
+
+    CONSTRAINT "DatFile_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DatFile_path_key" ON "DatFile"("path");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Platform_activeDatFileId_key" ON "Platform"("activeDatFileId");
+
+-- AddForeignKey
+ALTER TABLE "Platform" ADD CONSTRAINT "Platform_activeDatFileId_fkey" FOREIGN KEY ("activeDatFileId") REFERENCES "DatFile"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DatFile" ADD CONSTRAINT "DatFile_platformId_fkey" FOREIGN KEY ("platformId") REFERENCES "Platform"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -11,35 +11,38 @@ datasource db {
 }
 
 model Platform {
-  id         String     @id @default(cuid())
-  name       String     @unique
-  extensions String[]
-  libraries  Library[]
-  datEntries DatEntry[]
-  nointroDatUrl String? @map("nointro_dat_url")
+  id              String     @id @default(cuid())
+  name            String     @unique
+  extensions      String[]
+  libraries       Library[]
+  datEntries      DatEntry[]
+  datFiles        DatFile[]  @relation("PlatformDatFiles")
+  nointroDatUrl   String?    @map("nointro_dat_url")
+  activeDatFileId String?    @unique
+  activeDatFile   DatFile?   @relation("PlatformActiveDatFile", fields: [activeDatFileId], references: [id])
 }
 
 model Library {
-  id         String    @id @default(cuid())
-  path       String    @unique
+  id         String     @id @default(cuid())
+  path       String     @unique
   platformId String
-  platform   Platform  @relation(fields: [platformId], references: [id])
+  platform   Platform   @relation(fields: [platformId], references: [id])
   artifacts  Artifact[]
 }
 
 model Artifact {
-  id        String   @id @default(cuid())
-  libraryId String
-  library   Library  @relation(fields: [libraryId], references: [id])
-  path      String
-  size      Int
-  crc32     String?
-  sha1      String?
-  format    String?
-  multiPartGroup String? @map("multi_part_group")
-  releaseId String?
-  release   Release? @relation(fields: [releaseId], references: [id])
-  preferred Boolean @default(false)
+  id             String   @id @default(cuid())
+  libraryId      String
+  library        Library  @relation(fields: [libraryId], references: [id])
+  path           String
+  size           Int
+  crc32          String?
+  sha1           String?
+  format         String?
+  multiPartGroup String?  @map("multi_part_group")
+  releaseId      String?
+  release        Release? @relation(fields: [releaseId], references: [id])
+  preferred      Boolean  @default(false)
 
   @@unique([libraryId, path])
 }
@@ -55,27 +58,41 @@ model Game {
 }
 
 model Release {
-  id       String   @id @default(cuid())
-  gameId   String
-  game     Game     @relation(fields: [gameId], references: [id])
-  region   String?
-  language String?
+  id        String     @id @default(cuid())
+  gameId    String
+  game      Game       @relation(fields: [gameId], references: [id])
+  region    String?
+  language  String?
   artifacts Artifact[]
 }
 
-model DatEntry {
-  id             String   @id @default(cuid())
-  hashCrc        String?  @map("hash_crc")
-  hashSha1       String?  @map("hash_sha1")
-  canonicalName  String   @map("canonical_name")
-  region         String?
-  languages      String?
-  serial         String?
-  source         String
+model DatFile {
+  id             String    @id @default(cuid())
+  platform       Platform  @relation("PlatformDatFiles", fields: [platformId], references: [id])
   platformId     String
-  platform       Platform @relation(fields: [platformId], references: [id])
+  filename       String
+  path           String    @unique
+  size           BigInt
+  sha256         String
+  source         String? // "upload"|"remote"
+  version        String?
+  uploadedAt     DateTime  @default(now())
+  activatedAt    DateTime?
+  activePlatform Platform? @relation("PlatformActiveDatFile")
+}
+
+model DatEntry {
+  id            String   @id @default(cuid())
+  hashCrc       String?  @map("hash_crc")
+  hashSha1      String?  @map("hash_sha1")
+  canonicalName String   @map("canonical_name")
+  region        String?
+  languages     String?
+  serial        String?
+  source        String
+  platformId    String
+  platform      Platform @relation(fields: [platformId], references: [id])
 
   @@index([hashCrc])
   @@index([hashSha1])
 }
-


### PR DESCRIPTION
## Summary
- add `DatFile` model to store platform dat metadata
- allow `Platform` to reference its active dat file
- create Prisma migration for new table and relation

## Testing
- `pnpm --filter @gamearr/storage lint`
- `pnpm --filter @gamearr/storage test`
- `pnpm migrate` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68b288ac517c8330b6f146a55e3c21e2