### PR TITLE
feat(api): add platform CRUD endpoints

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -24,7 +24,8 @@
     "bullmq": "^5.0.0",
     "pino-http": "^9.0.0",
     "reflect-metadata": "^0.1.13",
-    "rxjs": "^7.8.2"
+    "rxjs": "^7.8.2",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@nestjs/testing": "^10.0.0",

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -19,6 +19,7 @@ async function bootstrap() {
     origin: process.env.FRONTEND_URL || 'http://localhost:5173',
   });
 
+
   // pino-http's type definitions lag behind the latest pino releases, so we
   // cast our shared logger to `any` to satisfy the expected interface.
   app.use(pinoHttp({ logger: logger as any }));

--- a/apps/api/src/platform/dto.ts
+++ b/apps/api/src/platform/dto.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const createPlatformSchema = z.object({
+  name: z.string(),
+  aliases: z.array(z.string()).optional(),
+});
+export type CreatePlatformDto = z.infer<typeof createPlatformSchema>;
+
+export const updatePlatformSchema = createPlatformSchema.partial();
+export type UpdatePlatformDto = z.infer<typeof updatePlatformSchema>;

--- a/apps/api/src/platform/platform.controller.ts
+++ b/apps/api/src/platform/platform.controller.ts
@@ -1,12 +1,44 @@
-import { Controller, Get, Inject } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Inject, Param, Patch, Post, UsePipes } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
 import { PlatformService } from './platform.service';
+import { CreatePlatformDto, UpdatePlatformDto, createPlatformSchema, updatePlatformSchema } from './dto';
+import { ZodValidationPipe } from '../zod-validation.pipe';
 
+@ApiTags('Platforms')
 @Controller('platforms')
 export class PlatformController {
   constructor(@Inject(PlatformService) private readonly service: PlatformService) {}
 
   @Get()
+  @ApiOperation({ summary: 'List platforms' })
   findAll() {
     return this.service.findAll();
   }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get platform details' })
+  findOne(@Param('id') id: string) {
+    return this.service.findOne(id);
+  }
+
+  @Post()
+  @ApiOperation({ summary: 'Create platform' })
+  @UsePipes(new ZodValidationPipe(createPlatformSchema))
+  create(@Body() body: CreatePlatformDto) {
+    return this.service.create(body);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update platform' })
+  @UsePipes(new ZodValidationPipe(updatePlatformSchema))
+  update(@Param('id') id: string, @Body() body: UpdatePlatformDto) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  @ApiOperation({ summary: 'Delete platform' })
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
+  }
 }
+

--- a/apps/api/src/platform/platform.service.ts
+++ b/apps/api/src/platform/platform.service.ts
@@ -1,11 +1,103 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library';
 import { PrismaService } from '../prisma/prisma.service.js';
+import type { CreatePlatformDto, UpdatePlatformDto } from './dto';
 
 @Injectable()
 export class PlatformService {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   findAll() {
-    return this.prisma.platform.findMany({ select: { id: true, name: true } });
+    return this.prisma.platform.findMany({
+      select: {
+        id: true,
+        name: true,
+        aliases: true,
+        activeDatFile: {
+          select: {
+            id: true,
+            filename: true,
+            version: true,
+            uploadedAt: true,
+            activatedAt: true,
+          },
+        },
+      },
+      orderBy: { name: 'asc' },
+    });
+  }
+
+  async findOne(id: string) {
+    const platform = await this.prisma.platform.findUnique({
+      where: { id },
+      select: {
+        id: true,
+        name: true,
+        aliases: true,
+        activeDatFile: {
+          select: {
+            id: true,
+            filename: true,
+            version: true,
+            uploadedAt: true,
+            activatedAt: true,
+          },
+        },
+        datFiles: {
+          orderBy: { uploadedAt: 'desc' },
+          select: {
+            id: true,
+            filename: true,
+            version: true,
+            uploadedAt: true,
+            activatedAt: true,
+          },
+        },
+      },
+    });
+    if (!platform) throw new NotFoundException('Platform not found');
+    return platform;
+  }
+
+  create(data: CreatePlatformDto) {
+    return this.prisma.platform.create({
+      data: { name: data.name, aliases: data.aliases ?? [], extensions: [] },
+      select: { id: true, name: true, aliases: true },
+    });
+  }
+
+  async update(id: string, data: UpdatePlatformDto) {
+    try {
+      return await this.prisma.platform.update({
+        where: { id },
+        data: {
+          ...(data.name ? { name: data.name } : {}),
+          ...(data.aliases ? { aliases: data.aliases } : {}),
+        },
+        select: { id: true, name: true, aliases: true },
+      });
+    } catch (err: any) {
+      if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+        throw new NotFoundException('Platform not found');
+      }
+      throw err;
+    }
+  }
+
+  async remove(id: string) {
+    const libraryCount = await this.prisma.library.count({ where: { platformId: id } });
+    if (libraryCount > 0) {
+      throw new BadRequestException('Platform has associated libraries');
+    }
+    try {
+      await this.prisma.platform.delete({ where: { id } });
+    } catch (err: any) {
+      if (err instanceof PrismaClientKnownRequestError && err.code === 'P2025') {
+        throw new NotFoundException('Platform not found');
+      }
+      throw err;
+    }
+    return { id };
   }
 }
+

--- a/apps/api/src/zod-validation.pipe.ts
+++ b/apps/api/src/zod-validation.pipe.ts
@@ -1,0 +1,14 @@
+import { BadRequestException, PipeTransform } from '@nestjs/common';
+import type { ZodSchema } from 'zod';
+
+export class ZodValidationPipe implements PipeTransform {
+  constructor(private schema: ZodSchema<any>) {}
+
+  transform(value: unknown) {
+    const result = this.schema.safeParse(value);
+    if (!result.success) {
+      throw new BadRequestException(result.error.issues);
+    }
+    return result.data;
+  }
+}

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -33,6 +33,44 @@
           }
         }
       }
+    },
+    "/platforms": {
+      "get": {
+        "operationId": "PlatformController_findAll",
+        "parameters": [],
+        "responses": {
+          "200": { "description": "" }
+        },
+        "tags": ["Platforms"]
+      },
+      "post": {
+        "operationId": "PlatformController_create",
+        "parameters": [],
+        "responses": {
+          "201": { "description": "" }
+        },
+        "tags": ["Platforms"]
+      }
+    },
+    "/platforms/{id}": {
+      "get": {
+        "operationId": "PlatformController_findOne",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": ""}},
+        "tags": ["Platforms"]
+      },
+      "patch": {
+        "operationId": "PlatformController_update",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": ""}},
+        "tags": ["Platforms"]
+      },
+      "delete": {
+        "operationId": "PlatformController_remove",
+        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "responses": {"200": {"description": ""}},
+        "tags": ["Platforms"]
+      }
     }
   },
   "info": {

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -14,6 +14,15 @@ export interface paths {
   "/live": {
     get: operations["HealthController_live"];
   };
+  "/platforms": {
+    get: operations["PlatformController_findAll"];
+    post: operations["PlatformController_create"];
+  };
+  "/platforms/{id}": {
+    get: operations["PlatformController_findOne"];
+    delete: operations["PlatformController_remove"];
+    patch: operations["PlatformController_update"];
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -49,6 +58,56 @@ export interface operations {
     };
   };
   HealthController_live: {
+    responses: {
+      200: {
+        content: never;
+      };
+    };
+  };
+  PlatformController_findAll: {
+    responses: {
+      200: {
+        content: never;
+      };
+    };
+  };
+  PlatformController_create: {
+    responses: {
+      201: {
+        content: never;
+      };
+    };
+  };
+  PlatformController_findOne: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      200: {
+        content: never;
+      };
+    };
+  };
+  PlatformController_remove: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      200: {
+        content: never;
+      };
+    };
+  };
+  PlatformController_update: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
     responses: {
       200: {
         content: never;

--- a/packages/storage/prisma/migrations/20250917090000_add_platform_aliases/migration.sql
+++ b/packages/storage/prisma/migrations/20250917090000_add_platform_aliases/migration.sql
@@ -1,0 +1,2 @@
+-- Add aliases column to Platform
+ALTER TABLE "Platform" ADD COLUMN "aliases" TEXT[];

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -13,6 +13,7 @@ datasource db {
 model Platform {
   id              String     @id @default(cuid())
   name            String     @unique
+  aliases         String[]
   extensions      String[]
   libraries       Library[]
   datEntries      DatEntry[]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,16 +43,16 @@ importers:
         version: link:../../packages/storage
       '@nestjs/common':
         specifier: ^10.0.0
-        version: 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        version: 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/core':
         specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+        version: 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nestjs/platform-express':
         specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
+        version: 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
       '@nestjs/swagger':
         specifier: ^7.2.0
-        version: 7.4.2(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)
+        version: 7.4.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)
       '@prisma/client':
         specifier: ^5.15.0
         version: 5.22.0(prisma@5.22.0)
@@ -62,6 +62,12 @@ importers:
       bullmq:
         specifier: ^5.0.0
         version: 5.58.2
+      class-transformer:
+        specifier: ^0.5.1
+        version: 0.5.1
+      class-validator:
+        specifier: ^0.14.0
+        version: 0.14.2
       pino-http:
         specifier: ^9.0.0
         version: 9.0.0
@@ -74,7 +80,7 @@ importers:
     devDependencies:
       '@nestjs/testing':
         specifier: ^10.0.0
-        version: 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20))
+        version: 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20))
       '@types/archiver':
         specifier: ^6.0.3
         version: 6.0.3
@@ -2000,6 +2006,9 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/validator@13.15.2':
+    resolution: {integrity: sha512-y7pa/oEJJ4iGYBxOpfAKn5b9+xuihvzDVnC/OSvlVnGxVg0pOqmjiMafiJ1KVNQEaPZf9HsEp5icEwGg8uIe5Q==}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2292,6 +2301,12 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+
+  class-validator@0.14.2:
+    resolution: {integrity: sha512-3kMVRF2io8N8pY1IFIXlho9r8IPUUIfHe2hYVtiebvAzU2XeQFXTv+XI4WX+TnXmtwXMDcjngcpkiPM0O9PvLw==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -3293,6 +3308,9 @@ packages:
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
+
+  libphonenumber-js@1.12.15:
+    resolution: {integrity: sha512-TMDCtIhWUDHh91wRC+wFuGlIzKdPzaTUHHVrIZ3vPUEoNaXFLrsIQ1ZpAeZeXApIF6rvDksMTvjrIQlLKaYxqQ==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -4575,6 +4593,10 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  validator@13.15.15:
+    resolution: {integrity: sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==}
+    engines: {node: '>= 0.10'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -5941,7 +5963,7 @@ snapshots:
   '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3':
     optional: true
 
-  '@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
       file-type: 20.4.1
       iterare: 1.2.1
@@ -5949,12 +5971,15 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
       uid: 2.0.2
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
+  '@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)':
     dependencies:
-      '@nestjs/common': 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
       iterare: 1.2.1
@@ -5964,19 +5989,22 @@ snapshots:
       tslib: 2.8.1
       uid: 2.0.2
     optionalDependencies:
-      '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
+      '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)':
+  '@nestjs/mapped-types@2.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)':
     dependencies:
-      '@nestjs/common': 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       reflect-metadata: 0.1.14
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
-  '@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
+  '@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)':
     dependencies:
-      '@nestjs/common': 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       body-parser: 1.20.3
       cors: 2.8.5
       express: 4.21.2
@@ -5985,25 +6013,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)':
+  '@nestjs/swagger@7.4.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)':
     dependencies:
       '@microsoft/tsdoc': 0.15.1
-      '@nestjs/common': 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(reflect-metadata@0.1.14)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/mapped-types': 2.0.5(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)
       js-yaml: 4.1.0
       lodash: 4.17.21
       path-to-regexp: 3.3.0
       reflect-metadata: 0.1.14
       swagger-ui-dist: 5.17.14
+    optionalDependencies:
+      class-transformer: 0.5.1
+      class-validator: 0.14.2
 
-  '@nestjs/testing@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20))':
+  '@nestjs/testing@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20))':
     dependencies:
-      '@nestjs/common': 10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2)
-      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/common': 10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2)
+      '@nestjs/core': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/platform-express@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)
       tslib: 2.8.1
     optionalDependencies:
-      '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
+      '@nestjs/platform-express': 10.4.20(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -6544,6 +6575,8 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/validator@13.15.2': {}
+
   '@vitejs/plugin-react@4.7.0(vite@5.4.19(@types/node@20.19.11)(terser@5.43.1))':
     dependencies:
       '@babel/core': 7.28.3
@@ -6884,6 +6917,14 @@ snapshots:
       fsevents: 2.3.3
 
   ci-info@3.9.0: {}
+
+  class-transformer@0.5.1: {}
+
+  class-validator@0.14.2:
+    dependencies:
+      '@types/validator': 13.15.2
+      libphonenumber-js: 1.12.15
+      validator: 13.15.15
 
   clsx@2.1.1: {}
 
@@ -7996,6 +8037,8 @@ snapshots:
       readable-stream: 2.3.8
 
   leven@3.1.0: {}
+
+  libphonenumber-js@1.12.15: {}
 
   lilconfig@3.1.3: {}
 
@@ -9306,6 +9349,8 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  validator@13.15.15: {}
 
   vary@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,12 +62,6 @@ importers:
       bullmq:
         specifier: ^5.0.0
         version: 5.58.2
-      class-transformer:
-        specifier: ^0.5.1
-        version: 0.5.1
-      class-validator:
-        specifier: ^0.14.0
-        version: 0.14.2
       pino-http:
         specifier: ^9.0.0
         version: 9.0.0
@@ -77,6 +71,9 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      zod:
+        specifier: ^3.22.4
+        version: 3.25.76
     devDependencies:
       '@nestjs/testing':
         specifier: ^10.0.0
@@ -6575,7 +6572,8 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
-  '@types/validator@13.15.2': {}
+  '@types/validator@13.15.2':
+    optional: true
 
   '@vitejs/plugin-react@4.7.0(vite@5.4.19(@types/node@20.19.11)(terser@5.43.1))':
     dependencies:
@@ -6918,13 +6916,15 @@ snapshots:
 
   ci-info@3.9.0: {}
 
-  class-transformer@0.5.1: {}
+  class-transformer@0.5.1:
+    optional: true
 
   class-validator@0.14.2:
     dependencies:
       '@types/validator': 13.15.2
       libphonenumber-js: 1.12.15
       validator: 13.15.15
+    optional: true
 
   clsx@2.1.1: {}
 
@@ -8038,7 +8038,8 @@ snapshots:
 
   leven@3.1.0: {}
 
-  libphonenumber-js@1.12.15: {}
+  libphonenumber-js@1.12.15:
+    optional: true
 
   lilconfig@3.1.3: {}
 
@@ -9350,7 +9351,8 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  validator@13.15.15: {}
+  validator@13.15.15:
+    optional: true
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary
- add CRUD controller/service for Platforms with zod validation
- expose aliases field in storage schema and migrations
- document platform endpoints in OpenAPI and SDK

## Testing
- `pnpm --filter @gamearr/api test`
- `pnpm exec openapi-typescript docs/openapi.json -o packages/sdk/src/index.ts`
- `DATA_ROOT=/tmp pnpm --filter @gamearr/api openapi` *(fails: Cannot read properties of undefined in @nestjs/swagger)*

------
https://chatgpt.com/codex/tasks/task_e_68b289f231d4833081832196c28fcdfd