### PR TITLE
feat(api): add platform dat upload

### DIFF
--- a/apps/api/src/platform/platform.controller.ts
+++ b/apps/api/src/platform/platform.controller.ts
@@ -1,5 +1,19 @@
-import { Body, Controller, Delete, Get, Inject, Param, Patch, Post, UsePipes } from '@nestjs/common';
-import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
+  Patch,
+  Post,
+  UploadedFile,
+  UseInterceptors,
+  UsePipes,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiConsumes } from '@nestjs/swagger';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { tmpdir } from 'node:os';
 import { PlatformService } from './platform.service';
 import { CreatePlatformDto, UpdatePlatformDto, createPlatformSchema, updatePlatformSchema } from './dto';
 import { ZodValidationPipe } from '../zod-validation.pipe';
@@ -39,6 +53,17 @@ export class PlatformController {
   @ApiOperation({ summary: 'Delete platform' })
   remove(@Param('id') id: string) {
     return this.service.remove(id);
+  }
+
+  @Post(':id/dat/upload')
+  @ApiOperation({ summary: 'Upload DAT file' })
+  @ApiConsumes('multipart/form-data')
+  @UseInterceptors(FileInterceptor('file', { dest: tmpdir() }))
+  uploadDat(
+    @Param('id') id: string,
+    @UploadedFile() file: { path: string; mimetype: string; originalname: string; size: number },
+  ) {
+    return this.service.uploadDat(id, file);
   }
 }
 


### PR DESCRIPTION
## Summary
- add `/platforms/:id/dat/upload` for uploading DAT files
- hash and store uploaded files under content-addressed paths
- enqueue BullMQ `dat:import` job after upload

## Testing
- `DATA_ROOT=$(mktemp -d) pnpm --filter @gamearr/api test`

------
https://chatgpt.com/codex/tasks/task_e_68b28fdbfc2c83309b92f3ea43b8f1aa