### PR TITLE
feat(api): add dat activation endpoints

### DIFF
--- a/apps/api/src/platform/platform.controller.ts
+++ b/apps/api/src/platform/platform.controller.ts
@@ -65,5 +65,17 @@ export class PlatformController {
   ) {
     return this.service.uploadDat(id, file);
   }
+
+  @Post(':id/dat/:datFileId/activate')
+  @ApiOperation({ summary: 'Activate DAT file' })
+  activate(@Param('id') id: string, @Param('datFileId') datFileId: string) {
+    return this.service.activateDat(id, datFileId);
+  }
+
+  @Post(':id/dat/:datFileId/deactivate')
+  @ApiOperation({ summary: 'Deactivate DAT file' })
+  deactivate(@Param('id') id: string, @Param('datFileId') datFileId: string) {
+    return this.service.deactivateDat(id, datFileId);
+  }
 }
 


### PR DESCRIPTION
## Summary
- add activate/deactivate endpoints for platform DAT files
- guard activation to matching platform

## Testing
- `pnpm --filter @gamearr/api lint`
- `pnpm --filter @gamearr/api test`
- `pnpm test` *(fails: @gamearr/web:test exited with 1)*

------
https://chatgpt.com/codex/tasks/task_e_68b2919b8e2c833086e2141b5ba6df06