### PR TITLE
Use active platform DAT for matching

### DIFF
--- a/.changeset/use-active-dat-for-matching.md
+++ b/.changeset/use-active-dat-for-matching.md
@@ -1,0 +1,4 @@
+---
+"@gamearr/worker": patch
+---
+Use platform's active DAT file when matching artifacts and skip matching if no active DAT is set.


### PR DESCRIPTION
## Summary
- use platform's active DAT file for artifact matching
- skip DAT matching when no active DAT is set

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b29af9654c833096950357b8afd6df