### PR TITLE
feat: add dat recheck job

### DIFF
--- a/apps/api/src/platform/platform.controller.ts
+++ b/apps/api/src/platform/platform.controller.ts
@@ -72,6 +72,12 @@ export class PlatformController {
     return this.service.activateDat(id, datFileId);
   }
 
+  @Post(':id/dat/recheck')
+  @ApiOperation({ summary: 'Recheck unmatched artifacts against active DAT' })
+  recheck(@Param('id') id: string) {
+    return this.service.recheckDat(id);
+  }
+
   @Post(':id/dat/:datFileId/deactivate')
   @ApiOperation({ summary: 'Deactivate DAT file' })
   deactivate(@Param('id') id: string, @Param('datFileId') datFileId: string) {

--- a/apps/api/src/platform/platform.service.ts
+++ b/apps/api/src/platform/platform.service.ts
@@ -190,7 +190,25 @@ export class PlatformService {
       }),
     ]);
 
+    if (this.datQueue) {
+      await this.datQueue.add('recheck-platform', { platformId });
+    }
+
     return { id: platformId, datFileId };
+  }
+
+  async recheckDat(platformId: string) {
+    const platform = await this.prisma.platform.findUnique({
+      where: { id: platformId },
+      select: { id: true },
+    });
+    if (!platform) throw new NotFoundException('Platform not found');
+
+    if (this.datQueue) {
+      await this.datQueue.add('recheck-platform', { platformId });
+      return { queued: true };
+    }
+    return { queued: false };
   }
 
   async deactivateDat(platformId: string, datFileId: string) {

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -4,7 +4,7 @@ import { config, logger, withCorrelationId } from '@gamearr/shared';
 import { scanProcessor } from './processors/scan';
 import { hashProcessor } from './processors/hash';
 import { importProcessor } from './processors/import';
-import { datImportProcessor } from './processors/datImport';
+import { datProcessor } from './processors/dat';
 import { startWatchCompleted } from './watchCompleted.js';
 import { startWatchQbittorrent } from './watchQbittorrent.js';
 
@@ -40,7 +40,7 @@ new Worker(
 );
 new Worker(
   datQueue.name,
-  (job: any) => withCorrelationId(() => datImportProcessor(job), job.id),
+  (job: any) => withCorrelationId(() => datProcessor(job), job.id),
   connection,
 );
 

--- a/apps/worker/src/processors/dat.ts
+++ b/apps/worker/src/processors/dat.ts
@@ -1,0 +1,16 @@
+import type { Job } from 'bullmq';
+import { datImportProcessor } from './datImport.js';
+import { datRecheckProcessor } from './datRecheck.js';
+
+export async function datProcessor(job: Job) {
+  switch (job.name) {
+    case 'import':
+      return datImportProcessor(job as any);
+    case 'recheck-platform':
+      return datRecheckProcessor(job as any);
+    default:
+      throw new Error(`Unknown job name ${job.name}`);
+  }
+}
+
+export default datProcessor;

--- a/apps/worker/src/processors/dat.ts
+++ b/apps/worker/src/processors/dat.ts
@@ -3,13 +3,15 @@ import { datImportProcessor } from './datImport.js';
 import { datRecheckProcessor } from './datRecheck.js';
 
 export async function datProcessor(job: Job) {
-  switch (job.name) {
+  const { name } = job as any;
+
+  switch (name) {
     case 'import':
       return datImportProcessor(job as any);
     case 'recheck-platform':
       return datRecheckProcessor(job as any);
     default:
-      throw new Error(`Unknown job name ${job.name}`);
+      throw new Error(`Unknown job name ${name}`);
   }
 }
 

--- a/apps/worker/src/processors/datRecheck.ts
+++ b/apps/worker/src/processors/datRecheck.ts
@@ -1,0 +1,84 @@
+import type { Job } from 'bullmq';
+import prisma from '@gamearr/storage/src/client';
+import { logger, addActivity } from '@gamearr/shared';
+
+interface RecheckJob {
+  platformId: string;
+}
+
+export async function datRecheckProcessor(job: Job<RecheckJob>) {
+  logger.info({ payload: job.data }, 'dat recheck job');
+  const { platformId } = job.data;
+  const platform = await prisma.platform.findUnique({
+    where: { id: platformId },
+    select: { id: true, name: true, activeDatFileId: true },
+  });
+  if (!platform) {
+    logger.warn({ platformId }, 'platform not found');
+    return;
+  }
+  if (!platform.activeDatFileId) {
+    logger.warn({ platformId }, 'platform has no active DAT');
+    return;
+  }
+  const artifacts = await prisma.artifact.findMany({
+    where: {
+      releaseId: null,
+      library: { platformId },
+      OR: [{ crc32: { not: null } }, { sha1: { not: null } }],
+    },
+    select: { id: true, crc32: true, sha1: true },
+  });
+  let matched = 0;
+  for (const artifact of artifacts) {
+    const datEntry = await prisma.datEntry.findFirst({
+      where: {
+        platformId,
+        datFileId: platform.activeDatFileId,
+        OR: [{ hashCrc: artifact.crc32 }, { hashSha1: artifact.sha1 }],
+      },
+    });
+    if (!datEntry) continue;
+    let game = await prisma.game.findFirst({
+      where: { provider: datEntry.source, providerId: datEntry.canonicalName },
+    });
+    if (!game) {
+      game = await prisma.game.create({
+        data: {
+          title: datEntry.canonicalName,
+          provider: datEntry.source,
+          providerId: datEntry.canonicalName,
+        },
+      });
+    }
+    let release = await prisma.release.findFirst({
+      where: {
+        gameId: game.id,
+        region: datEntry.region ?? undefined,
+        language: datEntry.languages ? datEntry.languages[0] : undefined,
+      },
+    });
+    if (!release) {
+      release = await prisma.release.create({
+        data: {
+          gameId: game.id,
+          region: datEntry.region,
+          language: datEntry.languages ? datEntry.languages[0] : undefined,
+        },
+      });
+    }
+    await prisma.artifact.update({
+      where: { id: artifact.id },
+      data: { releaseId: release.id },
+    });
+    matched++;
+  }
+  await addActivity({
+    type: 'match',
+    timestamp: new Date().toISOString(),
+    message: `DAT recheck matched ${matched} of ${artifacts.length} artifacts on ${platform.name}`,
+    details: { platformId, matched, total: artifacts.length },
+  });
+}
+
+export default datRecheckProcessor;


### PR DESCRIPTION
## Summary
- queue `dat:recheck-platform` after DAT activation and via manual endpoint
- add worker processor to recheck unmatched artifacts against active DAT

## Testing
- `pnpm --filter @gamearr/api test` *(fails: Cannot find module 'zod')*
- `pnpm --filter @gamearr/worker test`


------
https://chatgpt.com/codex/tasks/task_e_68b3207d9bd08330b25b8638a6d3076f