### PR TITLE
feat(web): add platform DAT management

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -12,6 +12,8 @@ import { Settings } from '../pages/Settings';
 import { SettingsOrganize } from '../pages/SettingsOrganize';
 import { SettingsExporters } from '../pages/SettingsExporters';
 import { SettingsProviders } from '../pages/SettingsProviders';
+import { SettingsPlatforms } from '../pages/SettingsPlatforms';
+import { SettingsPlatform } from '../pages/SettingsPlatform';
 import { Insights } from '../pages/Insights';
 import { Support } from '../pages/Support';
 import { Input } from '../components/ui/input';
@@ -174,6 +176,8 @@ export function Layout() {
             <Route path="/settings/organize" element={<SettingsOrganize />} />
             <Route path="/settings/exporters" element={<SettingsExporters />} />
             <Route path="/settings/providers" element={<SettingsProviders />} />
+            <Route path="/settings/platforms" element={<SettingsPlatforms />} />
+            <Route path="/settings/platforms/:id" element={<SettingsPlatform />} />
           <Route path="/support" element={<Support />} />
             <Route path="*" element={<Navigate to="/libraries" replace />} />
           </Routes>

--- a/apps/web/src/locales/en/settings.json
+++ b/apps/web/src/locales/en/settings.json
@@ -2,6 +2,7 @@
   "organizeSettings": "Organize Settings",
   "exporters": "Exporters",
   "providers": "Providers",
+  "platforms": "Platforms",
   "apiHealth": "API health: {{status}}",
   "regionPriority": "Region Priority",
   "preferVerified": "Prefer verified dumps",

--- a/apps/web/src/locales/es/settings.json
+++ b/apps/web/src/locales/es/settings.json
@@ -2,6 +2,7 @@
   "organizeSettings": "Configuración de organización",
   "exporters": "Exportadores",
   "providers": "Proveedores",
+  "platforms": "Plataformas",
   "apiHealth": "Estado de la API: {{status}}",
   "regionPriority": "Prioridad de región",
   "preferVerified": "Preferir volcados verificados",

--- a/apps/web/src/pages/Settings.tsx
+++ b/apps/web/src/pages/Settings.tsx
@@ -34,6 +34,11 @@ export function Settings() {
           {t('providers')}
         </Link>
       </div>
+      <div>
+        <Link to="/settings/platforms" className="text-blue-500 underline">
+          {t('platforms')}
+        </Link>
+      </div>
       <div>{t('apiHealth', { status: data ? 'ok' : '...' })}</div>
       <div>
         <label className="block mb-1">{t('regionPriority')}</label>

--- a/apps/web/src/pages/SettingsPlatform.tsx
+++ b/apps/web/src/pages/SettingsPlatform.tsx
@@ -1,0 +1,196 @@
+import { useParams, Link } from 'react-router-dom';
+import { useState } from 'react';
+import { useApiQuery, useApiMutation, ApiError } from '../lib/api';
+import { Button } from '../components/ui/button';
+import { toast } from 'sonner';
+
+const API_BASE = import.meta.env.VITE_API_URL ?? 'http://localhost:3000';
+
+interface DatFile {
+  id: string;
+  filename: string;
+  size?: number;
+  sha256?: string;
+  uploadedAt: string;
+  activatedAt?: string | null;
+}
+
+interface Platform {
+  id: string;
+  name: string;
+  datFiles: DatFile[];
+}
+
+export function SettingsPlatform() {
+  const { id } = useParams<{ id: string }>();
+  const { data, refetch } = useApiQuery<Platform>({
+    queryKey: ['platform', id],
+    path: `/platforms/${id}`,
+  });
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+
+  const activateMutation = useApiMutation<unknown, { datFileId: string }>(
+    ({ datFileId }) => ({
+      path: `/platforms/${id}/dat/${datFileId}/activate`,
+      init: { method: 'POST' },
+    }),
+    {
+      onSuccess: () => {
+        toast('Activated');
+        refetch();
+      },
+      onError: (err: ApiError) => toast.error(err.message),
+    },
+  );
+
+  const deactivateMutation = useApiMutation<unknown, { datFileId: string }>(
+    ({ datFileId }) => ({
+      path: `/platforms/${id}/dat/${datFileId}/deactivate`,
+      init: { method: 'POST' },
+    }),
+    {
+      onSuccess: () => {
+        toast('Deactivated');
+        refetch();
+      },
+      onError: (err: ApiError) => toast.error(err.message),
+    },
+  );
+
+  const deleteMutation = useApiMutation<unknown, { datFileId: string }>(
+    ({ datFileId }) => ({
+      path: `/platforms/${id}/dat/${datFileId}`,
+      init: { method: 'DELETE' },
+    }),
+    {
+      onSuccess: () => {
+        toast('Deleted');
+        refetch();
+      },
+      onError: (err: ApiError) => toast.error(err.message),
+    },
+  );
+
+  const recheckMutation = useApiMutation<unknown, void>(
+    () => ({ path: `/platforms/${id}/dat/recheck`, init: { method: 'POST' } }),
+    {
+      onSuccess: () => toast('Recheck started'),
+      onError: (err: ApiError) => toast.error(err.message),
+    },
+  );
+
+  const handleUpload = (file: File) => {
+    if (!file || !id) return;
+    const formData = new FormData();
+    formData.append('file', file);
+    const xhr = new XMLHttpRequest();
+    const token = localStorage.getItem('token');
+    xhr.open('POST', `${API_BASE}/platforms/${id}/dat/upload`);
+    if (token) xhr.setRequestHeader('Authorization', `Bearer ${token}`);
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) {
+        setUploadProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    };
+    xhr.onload = () => {
+      setUploadProgress(null);
+      if (xhr.status >= 200 && xhr.status < 300) {
+        toast('Upload complete');
+        refetch();
+      } else {
+        toast.error('Upload failed');
+      }
+    };
+    xhr.onerror = () => {
+      setUploadProgress(null);
+      toast.error('Upload failed');
+    };
+    xhr.send(formData);
+    toast('Upload started');
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <Link to="/settings/platforms" className="text-blue-500 underline">
+          &lt; Back to Platforms
+        </Link>
+      </div>
+      <h1 className="text-lg font-medium">{data?.name}</h1>
+      <div className="space-y-2">
+        <input
+          type="file"
+          accept=".xml,.dat,.zip,.7z"
+          onChange={(e) => {
+            const f = e.target.files?.[0];
+            if (f) handleUpload(f);
+          }}
+        />
+        {uploadProgress !== null && <div>Uploading {uploadProgress}%</div>}
+      </div>
+      <Button onClick={() => recheckMutation.mutate()} disabled={recheckMutation.isPending}>
+        Re-check unmatched with active DAT
+      </Button>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Filename</th>
+            <th className="text-left p-2">Size</th>
+            <th className="text-left p-2">SHA256</th>
+            <th className="text-left p-2">Uploaded</th>
+            <th className="text-left p-2">Activated</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {data?.datFiles.map((df) => (
+            <tr key={df.id} className="border-t">
+              <td className="p-2">{df.filename}</td>
+              <td className="p-2">
+                {df.size ? `${(df.size / 1024 / 1024).toFixed(2)} MB` : '-'}
+              </td>
+              <td className="p-2">{df.sha256 ? df.sha256.slice(0, 8) : '-'}</td>
+              <td className="p-2">
+                {df.uploadedAt
+                  ? new Date(df.uploadedAt).toLocaleDateString()
+                  : '-'}
+              </td>
+              <td className="p-2">
+                {df.activatedAt
+                  ? new Date(df.activatedAt).toLocaleDateString()
+                  : '-'}
+              </td>
+              <td className="p-2 space-x-2">
+                {df.activatedAt ? (
+                  <Button
+                    size="sm"
+                    onClick={() => deactivateMutation.mutate({ datFileId: df.id })}
+                  >
+                    Deactivate
+                  </Button>
+                ) : (
+                  <>
+                    <Button
+                      size="sm"
+                      onClick={() => activateMutation.mutate({ datFileId: df.id })}
+                    >
+                      Activate
+                    </Button>
+                    <Button
+                      size="sm"
+                      onClick={() => deleteMutation.mutate({ datFileId: df.id })}
+                    >
+                      Delete
+                    </Button>
+                  </>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default SettingsPlatform;

--- a/apps/web/src/pages/SettingsPlatforms.tsx
+++ b/apps/web/src/pages/SettingsPlatforms.tsx
@@ -1,0 +1,69 @@
+import { Link } from 'react-router-dom';
+import { useApiQuery } from '../lib/api';
+
+interface Platform {
+  id: string;
+  name: string;
+  aliases: string[];
+  activeDatFile?: {
+    version?: string;
+    activatedAt?: string | null;
+  } | null;
+  counts?: Record<string, number>;
+}
+
+export function SettingsPlatforms() {
+  const { data } = useApiQuery<Platform[]>({
+    queryKey: ['platforms'],
+    path: '/platforms',
+  });
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-lg font-medium">Platforms</h1>
+      <table className="w-full text-sm">
+        <thead>
+          <tr>
+            <th className="text-left p-2">Name</th>
+            <th className="text-left p-2">Aliases</th>
+            <th className="text-left p-2">Active DAT</th>
+            <th className="text-left p-2">Activated</th>
+            <th className="text-left p-2">Counts</th>
+            <th className="p-2" />
+          </tr>
+        </thead>
+        <tbody>
+          {data?.map((p) => (
+            <tr key={p.id} className="border-t">
+              <td className="p-2">{p.name}</td>
+              <td className="p-2">{p.aliases?.join(', ')}</td>
+              <td className="p-2">{p.activeDatFile?.version || '-'}</td>
+              <td className="p-2">
+                {p.activeDatFile?.activatedAt
+                  ? new Date(p.activeDatFile.activatedAt).toLocaleDateString()
+                  : '-'}
+              </td>
+              <td className="p-2">
+                {p.counts
+                  ? Object.entries(p.counts)
+                      .map(([k, v]) => `${k}: ${v}`)
+                      .join(', ')
+                  : '-'}
+              </td>
+              <td className="p-2">
+                <Link
+                  to={`/settings/platforms/${p.id}`}
+                  className="text-blue-500 underline"
+                >
+                  View
+                </Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default SettingsPlatforms;


### PR DESCRIPTION
## Summary
- add settings pages to manage platform DAT files
- support uploading, activating, deactivating and deleting DATs
- allow rechecking unmatched artifacts against active DAT

## Testing
- `pnpm --filter @gamearr/web test`

------
https://chatgpt.com/codex/tasks/task_e_68b3241299a48330a48c86c787245611