### PR TITLE
Add DAT fixture and parser unit test

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -7,7 +7,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx watch src/main.ts",
     "lint": "echo lint worker",
-    "test": "echo test worker"
+    "test": "node --test --import tsx test/parseDat.test.ts"
   },
   "dependencies": {
     "@gamearr/adapters": "workspace:*",

--- a/apps/worker/src/processors/datImport.ts
+++ b/apps/worker/src/processors/datImport.ts
@@ -58,7 +58,9 @@ async function readDatXml(filePath: string): Promise<string> {
   return await fs.readFile(filePath, 'utf8');
 }
 
-function parseDat(xml: string): { entries: ParsedEntry[]; version?: string; source: string } {
+export function parseDat(
+  xml: string,
+): { entries: ParsedEntry[]; version?: string; source: string } {
   const parser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: '' });
   const doc = parser.parse(xml);
   const header = doc?.datafile?.header ?? {};

--- a/apps/worker/test/fixtures/sample.dat
+++ b/apps/worker/test/fixtures/sample.dat
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datafile>
+  <header>
+    <name>Test DAT</name>
+    <author>No-Intro</author>
+    <version>1.0</version>
+  </header>
+  <game name="Game One" region="USA" languages="en,fr" serial="ABC123">
+    <rom name="Game One (USA)" crc="AAAAAAAA" md5="11111111111111111111111111111111" sha1="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" />
+  </game>
+  <game name="Game Two" region="Europe" language="es" catalog="XYZ987">
+    <rom name="Game Two (Europe)" crc="BBBBBBBB" md5="22222222222222222222222222222222" sha1="BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" version="Rev 1" />
+  </game>
+</datafile>

--- a/apps/worker/test/parseDat.test.ts
+++ b/apps/worker/test/parseDat.test.ts
@@ -1,0 +1,23 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+process.env.DATA_ROOT = '/tmp';
+const fixturePath = fileURLToPath(new URL('./fixtures/sample.dat', import.meta.url));
+
+test('XML parser returns normalized entries', async () => {
+  process.env.DATA_ROOT = '/tmp';
+  const { parseDat } = await import('../src/processors/datImport.js');
+  const xml = await readFile(fixturePath, 'utf8');
+  const { entries, source, version } = parseDat(xml);
+  assert.equal(entries.length, 2);
+  assert.equal(source, 'no-intro');
+  assert.equal(String(version), '1');
+  assert.equal(entries[0].region, 'USA');
+  assert.deepEqual(entries[0].languages, ['en', 'fr']);
+  assert.equal(entries[0].serial, 'ABC123');
+  assert.equal(entries[1].region, 'Europe');
+  assert.deepEqual(entries[1].languages, ['es']);
+  assert.equal(entries[1].serial, 'XYZ987');
+  assert.equal(entries[1].revision, 'Rev 1');
+});

--- a/apps/worker/tsconfig.json
+++ b/apps/worker/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "include": ["src", "types"]
+  "include": ["src", "types", "test"]
 }


### PR DESCRIPTION
## Summary
- add small sample DAT fixture
- export parser helper and cover normalization in a unit test

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68b339291e9c8330b54f7150852eb52e