### PR TITLE
feat: add indexer contract and demo indexer

### DIFF
--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -3,6 +3,7 @@ import * as igdbModule from './providers/igdb';
 import * as qbittorrentModule from './downloads/qbittorrent';
 import * as emulationstationModule from './exporters/emulationstation';
 import * as nointroDatModule from './dat/nointro';
+import demoIndexer from './indexers/demo.js';
 
 // Create and export the rawg object
 export const rawg = {
@@ -32,4 +33,8 @@ export const dat = {
     loadDat: nointroDatModule.loadNointroDat,
     parseDat: nointroDatModule.parseNointroDat,
   },
+};
+
+export const indexers = {
+  demo: demoIndexer,
 };

--- a/packages/adapters/src/indexers/demo.ts
+++ b/packages/adapters/src/indexers/demo.ts
@@ -1,0 +1,44 @@
+import type { Indexer, IndexerQuery, IndexerResult } from '@gamearr/domain';
+
+const data: IndexerResult[] = [
+  {
+    id: 'snes-1',
+    title: 'Super Mario World',
+    platform: 'snes',
+    size: 4096,
+    seeders: 20,
+    link: 'magnet:?xt=urn:btih:SMW',
+    protocol: 'torrent',
+  },
+  {
+    id: 'snes-2',
+    title: 'The Legend of Zelda: A Link to the Past',
+    platform: 'snes',
+    size: 4096,
+    seeders: 15,
+    link: 'magnet:?xt=urn:btih:ZELDA',
+    protocol: 'torrent',
+  },
+  {
+    id: 'snes-3',
+    title: 'Super Metroid',
+    platform: 'snes',
+    size: 4096,
+    seeders: 10,
+    link: 'magnet:?xt=urn:btih:METROID',
+    protocol: 'torrent',
+  },
+];
+
+export const demo: Indexer = {
+  name: 'demo',
+  async search(q: IndexerQuery): Promise<IndexerResult[]> {
+    return data.filter(r => {
+      const titleMatch = !q.title || r.title.toLowerCase().includes(q.title.toLowerCase());
+      const platformMatch = !q.platform || r.platform === q.platform;
+      return titleMatch && platformMatch;
+    });
+  },
+};
+
+export default demo;

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -6,3 +6,5 @@ export * from './parsers/gdi.js';
 export * from './organize/renderTemplate.js';
 export * from './organize/moveArtifact.js';
 export * from './organize/oneGameOneRom.js';
+export * from './indexers/types.js';
+export * from './indexers/registry.js';

--- a/packages/domain/src/indexers/registry.ts
+++ b/packages/domain/src/indexers/registry.ts
@@ -1,0 +1,15 @@
+import type { Indexer } from './types.js';
+
+const registry = new Map<string, Indexer>();
+
+export function registerIndexer(indexer: Indexer): void {
+  registry.set(indexer.name, indexer);
+}
+
+export function listIndexers(): Indexer[] {
+  return Array.from(registry.values());
+}
+
+export function getIndexer(name: string): Indexer | undefined {
+  return registry.get(name);
+}

--- a/packages/domain/src/indexers/types.ts
+++ b/packages/domain/src/indexers/types.ts
@@ -1,0 +1,23 @@
+export interface IndexerQuery {
+  title: string;
+  platform: string;
+  year?: number;
+  regionPref?: string[];
+}
+
+export interface IndexerResult {
+  id: string;
+  title: string;
+  platform: string;
+  size?: number;
+  seeders?: number;
+  isPassworded?: boolean;
+  link: string;
+  protocol: 'torrent' | 'nzb';
+  extra?: Record<string, unknown>;
+}
+
+export interface Indexer {
+  name: string;
+  search(q: IndexerQuery): Promise<IndexerResult[]>;
+}


### PR DESCRIPTION
## Summary
- add reusable Indexer interfaces and registry in domain package
- add demo in-memory indexer in adapters package
- expose indexer types, registry and demo indexer via package entrypoints

## Testing
- `pnpm --filter @gamearr/domain test`
- `pnpm --filter @gamearr/adapters test`
- `pnpm --filter @gamearr/adapters build`


------
https://chatgpt.com/codex/tasks/task_e_68b3542634f48330a4184c2bb35958fa