### PR TITLE
fix(storage): correct DatEntry foreign key constraint

### DIFF
--- a/packages/storage/prisma/migrations/20250919000000_fix_dat_entry_fk/migration.sql
+++ b/packages/storage/prisma/migrations/20250919000000_fix_dat_entry_fk/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "DatEntry" DROP CONSTRAINT "DatEntry_dat_file_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "DatEntry" ADD CONSTRAINT "DatEntry_dat_file_id_fkey" FOREIGN KEY ("dat_file_id") REFERENCES "DatFile"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary
- add missing migration to adjust DatEntry's dat_file_id foreign key behavior

## Testing
- `pnpm -w test`


------
https://chatgpt.com/codex/tasks/task_e_68b3d1fe24bc8330a3a39287a502521f