### PR TITLE
feat(worker): ingest completed qbit downloads

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -47,5 +47,5 @@ new Worker(
 
 logger.info({ queues: [scanQueue.name, hashQueue.name, importQueue.name, datQueue.name] }, 'worker started');
 startWatchCompleted();
-startWatchQbittorrent();
+startWatchQbittorrent(importQueue);
 startDatPrune(datQueue);

--- a/apps/worker/src/processors/import.ts
+++ b/apps/worker/src/processors/import.ts
@@ -1,8 +1,78 @@
 import type { Job } from 'bullmq';
-import { logger } from '@gamearr/shared';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { exec } from 'node:child_process';
+import { promisify } from 'node:util';
+import { randomUUID } from 'node:crypto';
+import { logger, config, addActivity } from '@gamearr/shared';
+import { hashFile } from '@gamearr/domain';
 
-export async function importProcessor(job: Job) {
+interface ImportJob {
+  path: string;
+}
+
+const execAsync = promisify(exec);
+
+async function processFile(fullPath: string, stagingDir: string, destRoot: string) {
+  const name = path.basename(fullPath);
+  let working = fullPath;
+  let tempDir: string | undefined;
+  const ext = path.extname(name).toLowerCase();
+
+  if (ext === '.zip') {
+    tempDir = path.join(stagingDir, path.parse(name).name);
+    await fs.mkdir(tempDir, { recursive: true });
+    await execAsync(`unzip -o ${JSON.stringify(fullPath)} -d ${JSON.stringify(tempDir)}`);
+    const items = await fs.readdir(tempDir);
+    if (items.length === 0) throw new Error('archive empty');
+    working = path.join(tempDir, items[0]);
+  } else if (ext === '.7z') {
+    throw new Error('7z archives not supported');
+  }
+
+  const { sha1 } = await hashFile(working);
+  await fs.mkdir(destRoot, { recursive: true });
+  const dest = path.join(destRoot, path.basename(working));
+  await fs.rename(working, dest);
+
+  await addActivity({
+    id: randomUUID(),
+    type: 'import',
+    timestamp: new Date().toISOString(),
+    message: `Imported ${name}`,
+    details: { file: name, hash: sha1, target: dest },
+  });
+
+  if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+  await fs.rm(fullPath, { force: true });
+}
+
+export async function importProcessor(job: Job<ImportJob>) {
   logger.info({ payload: job.data }, 'import job');
+  const root = config.paths.downloadsRoot;
+  if (!root) {
+    logger.warn('DOWNLOADS_ROOT is not set');
+    return;
+  }
+  const stagingDir = path.join(root, 'staging');
+  const destRoot = config.paths.libRoot || path.join(root, 'library');
+  await fs.mkdir(stagingDir, { recursive: true });
+  await fs.mkdir(destRoot, { recursive: true });
+
+  try {
+    await processFile(job.data.path, stagingDir, destRoot);
+  } catch (err: any) {
+    const id = randomUUID();
+    await addActivity({
+      id,
+      type: 'error',
+      timestamp: new Date().toISOString(),
+      message: err.message,
+      details: { file: path.basename(job.data.path) },
+      retry: { path: `/imports/activity/${id}/retry`, method: 'POST' },
+    });
+    logger.error({ err, file: job.data.path }, 'failed to import');
+  }
 }
 
 export default importProcessor;

--- a/apps/worker/src/watchCompleted.ts
+++ b/apps/worker/src/watchCompleted.ts
@@ -59,6 +59,13 @@ export function startWatchCompleted(interval = 5000) {
       const entries = await fs.readdir(completedDir);
       for (const entry of entries) {
         const full = path.join(completedDir, entry);
+        let stat;
+        try {
+          stat = await fs.stat(full);
+        } catch {
+          continue;
+        }
+        if (!stat.isFile()) continue;
         try {
           await processFile(full, completedDir, stagingDir);
         } catch (err: any) {

--- a/apps/worker/src/watchQbittorrent.ts
+++ b/apps/worker/src/watchQbittorrent.ts
@@ -1,16 +1,19 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
+import { Queue } from 'bullmq';
 import { QbitClient } from '@gamearr/adapters';
 import { config, logger, readSettings } from '@gamearr/shared';
+import prisma from '@gamearr/storage/src/client';
+import { walk } from '@gamearr/domain';
 
-export function startWatchQbittorrent(interval = 5000) {
+export function startWatchQbittorrent(importQueue: Queue, interval = 10000) {
   const root = config.paths.downloadsRoot;
   if (!root) {
     logger.warn('DOWNLOADS_ROOT is not set');
     return;
   }
-  const completedDir = path.join(root, 'completed');
-  fs.mkdir(completedDir, { recursive: true });
+  const ingestRoot = path.join(root, 'completed', '_ingest');
+  fs.mkdir(ingestRoot, { recursive: true });
 
   (async () => {
     try {
@@ -29,17 +32,60 @@ export function startWatchQbittorrent(interval = 5000) {
 
       setInterval(async () => {
         try {
-          const torrents = await client.listTorrents();
+          const torrents = await client.listTorrents({ category: 'gamearr' });
           for (const t of torrents) {
-            if (t.state === 'completed') {
+            if (
+              ['stalledUP', 'uploading', 'pausedUP', 'completed'].includes(t.state) &&
+              t.progress >= 1
+            ) {
+              const download = await prisma.download.findFirst({
+                where: { payload: { path: ['hash'], equals: t.hash } },
+              });
+              if (download && !(download as any).doneAt) {
+                await prisma.download.update({
+                  where: { id: download.id },
+                  data: { state: 'completed', doneAt: new Date() },
+                });
+              }
+
               const src =
                 t.content_path || (t.save_path ? path.join(t.save_path, t.name) : undefined);
               if (!src) continue;
-              const dest = path.join(completedDir, path.basename(src));
+              const dest = path.join(ingestRoot, t.name);
+              let finalPath = dest;
               try {
-                await fs.rename(src, dest);
+                await fs.mkdir(path.dirname(dest), { recursive: true });
+                if (path.resolve(src) !== path.resolve(dest)) {
+                  try {
+                    await fs.rename(src, dest);
+                  } catch (err) {
+                    await fs.cp(src, dest, { recursive: true });
+                  }
+                }
               } catch (err) {
                 logger.error({ err, src, dest }, 'failed to move completed torrent');
+                finalPath = src;
+              }
+
+              const files: string[] = [];
+              try {
+                const stat = await fs.stat(finalPath);
+                if (stat.isDirectory()) {
+                  for await (const file of walk(finalPath)) files.push(file);
+                } else {
+                  files.push(finalPath);
+                }
+              } catch (err) {
+                logger.error({ err, path: finalPath }, 'failed to list files');
+                continue;
+              }
+
+              for (const file of files) {
+                try {
+                  await importQueue.add('import', { path: file });
+                } catch (err) {
+                  logger.error({ err, file }, 'failed to enqueue import job');
+                }
               }
             }
           }

--- a/packages/storage/prisma/migrations/20250920000000_add_download_done_at/migration.sql
+++ b/packages/storage/prisma/migrations/20250920000000_add_download_done_at/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Download" ADD COLUMN "done_at" TIMESTAMP(3);

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -112,4 +112,5 @@ model Download {
   client    String
   payload   Json
   createdAt DateTime @default(now()) @map("created_at")
+  doneAt    DateTime? @map("done_at")
 }


### PR DESCRIPTION
## Summary
- poll qBittorrent for finished torrents and enqueue imports
- add Download.doneAt and migration

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4c0c9bd1c8330afa9a92966732480