### PR TITLE
feat(api): add search module

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -14,6 +14,7 @@ import { SettingsModule } from './settings/settings.module.js';
 import { ProvidersModule } from './providers/providers.module.js';
 import { MetricsModule } from './metrics/metrics.module.js';
 import { SupportModule } from './support/support.module.js';
+import { SearchModule } from './search/search.module.js';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { SupportModule } from './support/support.module.js';
     ProvidersModule,
     MetricsModule,
     SupportModule,
+    SearchModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/downloads/downloads.module.ts
+++ b/apps/api/src/downloads/downloads.module.ts
@@ -7,5 +7,6 @@ import { PrismaModule } from '../prisma/prisma.module.js';
   imports: [PrismaModule],
   controllers: [DownloadsController],
   providers: [DownloadsService],
+  exports: [DownloadsService],
 })
 export class DownloadsModule {}

--- a/apps/api/src/search/search.controller.ts
+++ b/apps/api/src/search/search.controller.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Query, Post, Body, Inject } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { SearchService } from './search.service.js';
+
+@ApiTags('search')
+@Controller()
+export class SearchController {
+  constructor(@Inject(SearchService) private readonly service: SearchService) {}
+
+  @Get('search')
+  search(
+    @Query('title') title = '',
+    @Query('platform') platform = '',
+    @Query('year') year?: string,
+    @Query('regionPref') regionPref?: string,
+  ) {
+    const regions = regionPref
+      ? regionPref
+          .split(',')
+          .map((r) => r.trim())
+          .filter(Boolean)
+      : undefined;
+    return this.service.search({
+      title,
+      platform,
+      year: year ? Number(year) : undefined,
+      regionPref: regions,
+    });
+  }
+
+  @Post('downloads/from-search')
+  download(@Body() body: { indexer: string; id: string; category?: string }) {
+    return this.service.downloadFromSearch(
+      body.indexer,
+      body.id,
+      body.category,
+    );
+  }
+}
+

--- a/apps/api/src/search/search.module.ts
+++ b/apps/api/src/search/search.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { registerIndexer } from '@gamearr/domain';
+import { indexers } from '@gamearr/adapters';
+import { DownloadsModule } from '../downloads/downloads.module.js';
+import { SearchController } from './search.controller.js';
+import { SearchService } from './search.service.js';
+
+@Module({
+  imports: [DownloadsModule],
+  controllers: [SearchController],
+  providers: [SearchService],
+})
+export class SearchModule {
+  constructor() {
+    Object.values(indexers).forEach(registerIndexer);
+  }
+}
+

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -1,0 +1,100 @@
+import { Injectable, Inject } from '@nestjs/common';
+import {
+  listIndexers,
+  getIndexer,
+  type IndexerResult,
+  type IndexerQuery,
+} from '@gamearr/domain';
+import { DownloadsService } from '../downloads/downloads.service.js';
+
+interface SearchQuery {
+  title?: string;
+  platform?: string;
+  year?: number;
+  regionPref?: string[];
+}
+
+@Injectable()
+export class SearchService {
+  constructor(
+    @Inject(DownloadsService) private readonly downloads: DownloadsService,
+  ) {}
+
+  private cache = new Map<string, IndexerResult>();
+
+  async search(
+    q: SearchQuery,
+  ): Promise<(IndexerResult & { indexer: string })[]> {
+    const query: IndexerQuery = {
+      title: q.title ?? '',
+      platform: q.platform ?? '',
+      year: q.year,
+      regionPref: q.regionPref,
+    };
+
+    const indexers = listIndexers();
+    const results = (
+      await Promise.all(
+        indexers.map(async (idx) => {
+          const res = await idx.search(query);
+          return res.map((r) => {
+            const normalized: IndexerResult = {
+              ...r,
+              size:
+                typeof r.size === 'number'
+                  ? r.size
+                  : r.size
+                    ? Number(r.size)
+                    : 0,
+              seeders:
+                typeof r.seeders === 'number'
+                  ? r.seeders
+                  : r.seeders
+                    ? Number(r.seeders)
+                    : 0,
+              isPassworded: r.isPassworded ?? false,
+            };
+            const withIndexer = { indexer: idx.name, ...normalized };
+            this.cache.set(`${idx.name}:${r.id}`, normalized);
+            return withIndexer;
+          });
+        }),
+      )
+    ).flat();
+
+    results.sort((a, b) => {
+      if (a.isPassworded !== b.isPassworded)
+        return a.isPassworded ? 1 : -1;
+      if ((a.seeders ?? 0) !== (b.seeders ?? 0))
+        return (b.seeders ?? 0) - (a.seeders ?? 0);
+      return (a.size ?? 0) - (b.size ?? 0);
+    });
+
+    return results;
+  }
+
+  async downloadFromSearch(
+    indexerName: string,
+    id: string,
+    category?: string,
+  ) {
+    const key = `${indexerName}:${id}`;
+    let result = this.cache.get(key);
+    if (!result) {
+      const indexer = getIndexer(indexerName);
+      if (!indexer) {
+        throw new Error('Indexer not found');
+      }
+      const res = await indexer.search({ title: '', platform: '' });
+      result = res.find((r) => r.id === id);
+      if (!result) {
+        throw new Error('Result not found');
+      }
+    }
+    if (!result.link.startsWith('magnet:')) {
+      throw new Error('Unsupported link');
+    }
+    return this.downloads.addMagnet(result.link, category);
+  }
+}
+


### PR DESCRIPTION
## Summary
- add SearchModule with indexer registry
- expose GET /search and download from search route
- export DownloadsService for reuse

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca6a869c83309061a57d91881307