### PR TITLE
feat: enhance library management

### DIFF
--- a/apps/api/src/imports/imports.service.ts
+++ b/apps/api/src/imports/imports.service.ts
@@ -20,8 +20,12 @@ export class ImportsService {
     if (!artifact) {
       throw new NotFoundException('Artifact not found');
     }
-    const path = await moveArtifact(artifact as any, template, romsRoot);
-    return { path };
+    if (!artifact.library.autoOrganizeOnImport) {
+      const src = path.join(artifact.library.path, artifact.path);
+      return { path: src };
+    }
+    const organized = await moveArtifact(artifact as any, template, romsRoot);
+    return { path: organized };
   }
 
   async preview(artifactId: string, template: string, romsRoot = '/roms') {

--- a/apps/api/src/imports/organize.test.ts
+++ b/apps/api/src/imports/organize.test.ts
@@ -24,7 +24,7 @@ test('POST /imports/organize moves artifact', async () => {
     id: '1',
     path: 'Sonic.bin',
     multiPartGroup: null,
-    library: { path: libraryPath, platform: { name: 'Dreamcast' } },
+    library: { path: libraryPath, platform: { name: 'Dreamcast' }, autoOrganizeOnImport: true },
     release: { game: { title: 'Sonic' } },
   };
 
@@ -55,5 +55,56 @@ test('POST /imports/organize moves artifact', async () => {
   assert.equal(json.path, path.join(romsPath, 'Dreamcast/Sonic.bin'));
   const moved = await fs.readFile(path.join(romsPath, 'Dreamcast/Sonic.bin'), 'utf8');
   assert.equal(moved, 'data');
+  await app.close();
+});
+
+test('POST /imports/organize respects autoOrganizeOnImport', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'organize-')); 
+  const libraryPath = path.join(tmp, 'library');
+  await fs.mkdir(libraryPath, { recursive: true });
+  const source = path.join(libraryPath, 'Sonic.bin');
+  await fs.writeFile(source, 'data');
+  const romsPath = path.join(tmp, 'roms');
+  await fs.mkdir(path.join(romsPath, 'Dreamcast'), { recursive: true });
+
+  const artifact = {
+    id: '1',
+    path: 'Sonic.bin',
+    multiPartGroup: null,
+    library: {
+      path: libraryPath,
+      platform: { name: 'Dreamcast' },
+      autoOrganizeOnImport: false,
+    },
+    release: { game: { title: 'Sonic' } },
+  };
+
+  const prismaStub = {
+    artifact: {
+      findUnique: async () => artifact,
+    },
+  };
+
+  const moduleRef = await NestTest.createTestingModule({
+    controllers: [ImportsController],
+    providers: [ImportsService, { provide: PrismaService, useValue: prismaStub }],
+  }).compile();
+
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+
+  const template = '${game}${disc? ` (Disc ${disc})`:``}';
+  const res = await fetch(`http://localhost:${port}/imports/organize`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ artifactId: '1', template, romsRoot: romsPath }),
+  });
+  const json = await res.json();
+  assert.equal(json.path, source);
+  const exists = await fs.readFile(source, 'utf8');
+  assert.equal(exists, 'data');
   await app.close();
 });

--- a/apps/api/src/library/library.controller.ts
+++ b/apps/api/src/library/library.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Inject } from '@nestjs/common';
+import { Body, Controller, Get, Param, Post, Inject, Put, Delete } from '@nestjs/common';
 import { LibraryService } from './library.service';
 
 @Controller('libraries')
@@ -6,13 +6,30 @@ export class LibraryController {
   constructor(@Inject(LibraryService) private readonly service: LibraryService) {}
 
   @Post()
-  create(@Body() body: { path: string; platformId: string }) {
+  create(
+    @Body()
+    body: { path: string; platformId: string; autoOrganizeOnImport?: boolean },
+  ) {
     return this.service.create(body);
   }
 
   @Get()
   findAll() {
     return this.service.findAll();
+  }
+
+  @Put(':id')
+  update(
+    @Param('id') id: string,
+    @Body()
+    body: { path?: string; platformId?: string; autoOrganizeOnImport?: boolean },
+  ) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.service.remove(id);
   }
 
   @Post(':id/scan')

--- a/apps/worker/src/processors/scan.ts
+++ b/apps/worker/src/processors/scan.ts
@@ -50,6 +50,10 @@ export async function scanProcessor(job: Job<{ libraryId: string }>) {
       });
     }
   }
+  await prisma.library.update({
+    where: { id: libraryId },
+    data: { lastScannedAt: new Date() },
+  });
 }
 
 export default scanProcessor;

--- a/packages/storage/prisma/migrations/20250901000000_library_auto_organize/migration.sql
+++ b/packages/storage/prisma/migrations/20250901000000_library_auto_organize/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Library" ADD COLUMN "autoOrganizeOnImport" BOOLEAN NOT NULL DEFAULT true;
+ALTER TABLE "Library" ADD COLUMN "lastScannedAt" TIMESTAMP(3);

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -29,6 +29,8 @@ model Library {
   platformId String
   platform   Platform   @relation(fields: [platformId], references: [id])
   artifacts  Artifact[]
+  autoOrganizeOnImport Boolean  @default(true)
+  lastScannedAt        DateTime?
 }
 
 model Artifact {


### PR DESCRIPTION
## Summary
- add per-library auto-organize setting with last scan tracking
- expose artifact and unmatched counts in library API and UI
- respect auto-organize flag during imports

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4e8b75e2083308c6cb29247def516