### PR TITLE
feat: library organize preview and apply

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -15,6 +15,7 @@ import { ProvidersModule } from './providers/providers.module.js';
 import { MetricsModule } from './metrics/metrics.module.js';
 import { SupportModule } from './support/support.module.js';
 import { SearchModule } from './search/search.module.js';
+import { OrganizeModule } from './organize/organize.module.js';
 
 @Module({
   imports: [
@@ -34,6 +35,7 @@ import { SearchModule } from './search/search.module.js';
     MetricsModule,
     SupportModule,
     SearchModule,
+    OrganizeModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/imports/imports.controller.ts
+++ b/apps/api/src/imports/imports.controller.ts
@@ -10,11 +10,6 @@ export class ImportsController {
     return this.service.organize(body.artifactId, body.template, body.romsRoot);
   }
 
-  @Post('organize/preview')
-  preview(@Body() body: { artifactId: string; template: string; romsRoot?: string }) {
-    return this.service.preview(body.artifactId, body.template, body.romsRoot);
-  }
-
   @Get('activity')
   activity() {
     return this.service.activity();

--- a/apps/api/src/imports/imports.service.ts
+++ b/apps/api/src/imports/imports.service.ts
@@ -1,9 +1,8 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { moveArtifact, renderTemplate } from '@gamearr/domain';
+import { moveArtifact } from '@gamearr/domain';
 import { readActivity, removeActivity } from '@gamearr/shared';
 import { PrismaService } from '../prisma/prisma.service.js';
 import path from 'node:path';
-import { BadRequestException } from '@nestjs/common';
 
 @Injectable()
 export class ImportsService {
@@ -26,33 +25,6 @@ export class ImportsService {
     }
     const organized = await moveArtifact(artifact as any, template, romsRoot);
     return { path: organized };
-  }
-
-  async preview(artifactId: string, template: string, romsRoot = '/roms') {
-    const artifact = await this.prisma.artifact.findUnique({
-      where: { id: artifactId },
-      include: {
-        library: { include: { platform: true } },
-        release: { include: { game: true } },
-      },
-    });
-    if (!artifact) {
-      throw new NotFoundException('Artifact not found');
-    }
-    const ext = path.extname(artifact.path);
-    const ctx = {
-      platform: artifact.library.platform.name,
-      game: artifact.release?.game.title ?? path.parse(artifact.path).name,
-      disc: artifact.multiPartGroup ?? '',
-      ext,
-    } as Record<string, unknown>;
-    try {
-      const name = renderTemplate(ctx, template) + ext;
-      const dest = path.join(romsRoot, artifact.library.platform.name, name);
-      return { path: dest };
-    } catch (err: any) {
-      throw new BadRequestException(err.message);
-    }
   }
 
   async activity() {

--- a/apps/api/src/organize/library.test.ts
+++ b/apps/api/src/organize/library.test.ts
@@ -1,0 +1,89 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { Test as NestTest } from '@nestjs/testing';
+import { OrganizeController } from './organize.controller.js';
+import { OrganizeService } from './organize.service.js';
+import { PrismaService } from '../prisma/prisma.service.js';
+
+test('POST /organize/library/:id dryRun returns renames', async () => {
+  const artifact = {
+    id: '1',
+    path: 'Sonic.bin',
+    multiPartGroup: null,
+    library: { id: 'lib', path: '/library', platform: { name: 'Dreamcast' } },
+    release: { game: { title: 'Sonic' } },
+  };
+  const prismaStub = {
+    artifact: {
+      findMany: async () => [artifact],
+    },
+  };
+  const moduleRef = await NestTest.createTestingModule({
+    controllers: [OrganizeController],
+    providers: [OrganizeService, { provide: PrismaService, useValue: prismaStub }],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+  const template = '${game}${disc? ` (Disc ${disc})`:``}';
+  const res = await fetch(`http://localhost:${port}/organize/library/lib`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ template, dryRun: true, romsRoot: '/roms' }),
+  });
+  const json = await res.json();
+  assert.deepEqual(json.renames, [
+    {
+      from: path.join('/library', 'Sonic.bin'),
+      to: path.join('/roms', 'Dreamcast/Sonic.bin'),
+    },
+  ]);
+  await app.close();
+});
+
+test('POST /organize/library/:id moves files', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'organize-lib-'));
+  const libraryPath = path.join(tmp, 'library');
+  await fs.mkdir(libraryPath, { recursive: true });
+  const source = path.join(libraryPath, 'Sonic.bin');
+  await fs.writeFile(source, 'data');
+  const romsRoot = path.join(tmp, 'roms');
+  await fs.mkdir(path.join(romsRoot, 'Dreamcast'), { recursive: true });
+  const artifact = {
+    id: '1',
+    path: 'Sonic.bin',
+    multiPartGroup: null,
+    library: { id: 'lib', path: libraryPath, platform: { name: 'Dreamcast' } },
+    release: { game: { title: 'Sonic' } },
+  };
+  const prismaStub = {
+    artifact: {
+      findMany: async () => [artifact],
+    },
+  };
+  const moduleRef = await NestTest.createTestingModule({
+    controllers: [OrganizeController],
+    providers: [OrganizeService, { provide: PrismaService, useValue: prismaStub }],
+  }).compile();
+  const app = moduleRef.createNestApplication();
+  await app.init();
+  await app.listen(0);
+  const server = app.getHttpServer();
+  const { port } = server.address();
+  const template = '${game}${disc? ` (Disc ${disc})`:``}';
+  const res = await fetch(`http://localhost:${port}/organize/library/lib`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ template, romsRoot }),
+  });
+  const json = await res.json();
+  assert.equal(json.renames[0].to, path.join(romsRoot, 'Dreamcast/Sonic.bin'));
+  const moved = await fs.readFile(path.join(romsRoot, 'Dreamcast/Sonic.bin'), 'utf8');
+  assert.equal(moved, 'data');
+  await app.close();
+});

--- a/apps/api/src/organize/organize.controller.ts
+++ b/apps/api/src/organize/organize.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Post, Param, Inject } from '@nestjs/common';
+import { OrganizeService } from './organize.service.js';
+
+@Controller('organize')
+export class OrganizeController {
+  constructor(@Inject(OrganizeService) private readonly service: OrganizeService) {}
+
+  @Post('preview')
+  preview(
+    @Body() body: { artifactId: string; template: string; romsRoot?: string },
+  ) {
+    return this.service.preview(body.artifactId, body.template, body.romsRoot);
+  }
+
+  @Post('library/:id')
+  organizeLibrary(
+    @Param('id') id: string,
+    @Body()
+    body: { template: string; dryRun?: boolean; romsRoot?: string },
+  ) {
+    return this.service.organizeLibrary(
+      id,
+      body.template,
+      body.dryRun ?? false,
+      body.romsRoot,
+    );
+  }
+}

--- a/apps/api/src/organize/organize.module.ts
+++ b/apps/api/src/organize/organize.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { OrganizeController } from './organize.controller.js';
+import { OrganizeService } from './organize.service.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [OrganizeController],
+  providers: [OrganizeService],
+})
+export class OrganizeModule {}

--- a/apps/api/src/organize/organize.service.ts
+++ b/apps/api/src/organize/organize.service.ts
@@ -1,4 +1,9 @@
-import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Inject,
+} from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { renderTemplate } from '@gamearr/domain';
 import path from 'node:path';
@@ -6,7 +11,7 @@ import fs from 'node:fs/promises';
 
 @Injectable()
 export class OrganizeService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
 
   async preview(artifactId: string, template: string, romsRoot = '/roms') {
     const artifact = await this.prisma.artifact.findUnique({
@@ -48,6 +53,9 @@ export class OrganizeService {
         release: { include: { game: true } },
       },
     });
+    if (artifacts.length === 0) {
+      throw new NotFoundException('No artifacts found');
+    }
     const renames: { from: string; to: string }[] = [];
     for (const artifact of artifacts as any[]) {
       const src = path.join(artifact.library.path, artifact.path);

--- a/apps/api/src/organize/organize.service.ts
+++ b/apps/api/src/organize/organize.service.ts
@@ -1,0 +1,71 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { renderTemplate } from '@gamearr/domain';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+
+@Injectable()
+export class OrganizeService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async preview(artifactId: string, template: string, romsRoot = '/roms') {
+    const artifact = await this.prisma.artifact.findUnique({
+      where: { id: artifactId },
+      include: {
+        library: { include: { platform: true } },
+        release: { include: { game: true } },
+      },
+    });
+    if (!artifact) {
+      throw new NotFoundException('Artifact not found');
+    }
+    const ext = path.extname(artifact.path);
+    const ctx = {
+      platform: artifact.library.platform.name,
+      game: artifact.release?.game.title ?? path.parse(artifact.path).name,
+      disc: artifact.multiPartGroup ?? '',
+      ext,
+    } as Record<string, unknown>;
+    try {
+      const name = renderTemplate(ctx, template) + ext;
+      const dest = path.join(romsRoot, artifact.library.platform.name, name);
+      return { path: dest };
+    } catch (err: any) {
+      throw new BadRequestException(err.message);
+    }
+  }
+
+  async organizeLibrary(
+    libraryId: string,
+    template: string,
+    dryRun = false,
+    romsRoot = '/roms',
+  ) {
+    const artifacts = await this.prisma.artifact.findMany({
+      where: { libraryId },
+      include: {
+        library: { include: { platform: true } },
+        release: { include: { game: true } },
+      },
+    });
+    const renames: { from: string; to: string }[] = [];
+    for (const artifact of artifacts as any[]) {
+      const src = path.join(artifact.library.path, artifact.path);
+      const ext = path.extname(artifact.path);
+      const ctx = {
+        platform: artifact.library.platform.name,
+        game: artifact.release?.game.title ?? path.parse(artifact.path).name,
+        disc: artifact.multiPartGroup ?? '',
+        ext,
+      } as Record<string, unknown>;
+      const name = renderTemplate(ctx, template) + ext;
+      const dest = path.join(romsRoot, artifact.library.platform.name, name);
+      renames.push({ from: src, to: dest });
+      if (!dryRun) {
+        await fs.mkdir(path.dirname(dest), { recursive: true });
+        await fs.rename(src, dest);
+      }
+    }
+    return { renames };
+  }
+}

--- a/apps/api/src/organize/preview.test.ts
+++ b/apps/api/src/organize/preview.test.ts
@@ -2,8 +2,8 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import path from 'node:path';
 import { Test as NestTest } from '@nestjs/testing';
-import { ImportsController } from './imports.controller.js';
-import { ImportsService } from './imports.service.js';
+import { OrganizeController } from './organize.controller.js';
+import { OrganizeService } from './organize.service.js';
 import { PrismaService } from '../prisma/prisma.service.js';
 
 const artifact = {
@@ -14,7 +14,7 @@ const artifact = {
   release: { game: { title: 'Sonic' } },
 };
 
-test('POST /imports/organize/preview returns path', async () => {
+test('POST /organize/preview returns path', async () => {
   const prismaStub = {
     artifact: {
       findUnique: async () => artifact,
@@ -22,8 +22,8 @@ test('POST /imports/organize/preview returns path', async () => {
   };
 
   const moduleRef = await NestTest.createTestingModule({
-    controllers: [ImportsController],
-    providers: [ImportsService, { provide: PrismaService, useValue: prismaStub }],
+    controllers: [OrganizeController],
+    providers: [OrganizeService, { provide: PrismaService, useValue: prismaStub }],
   }).compile();
 
   const app = moduleRef.createNestApplication();
@@ -33,7 +33,7 @@ test('POST /imports/organize/preview returns path', async () => {
   const { port } = server.address();
 
   const template = '${game}${disc? ` (Disc ${disc})`:``}';
-  const res = await fetch(`http://localhost:${port}/imports/organize/preview`, {
+  const res = await fetch(`http://localhost:${port}/organize/preview`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ artifactId: '1', template, romsRoot: '/roms' }),

--- a/apps/web/src/pages/SettingsOrganize.tsx
+++ b/apps/web/src/pages/SettingsOrganize.tsx
@@ -136,7 +136,7 @@ export function SettingsOrganize() {
         <button
           className="px-4 py-2 bg-purple-500 text-white rounded"
           onClick={() => dryRunMutation.mutate({ libraryId })}
-          disabled={!libraryId}
+          disabled={!libraryId || !artifacts?.length}
         >
           Apply to Library
         </button>


### PR DESCRIPTION
## Summary
- add organize controller/service for artifact preview and library-wide apply
- support dry-run and apply operations for organizing libraries
- extend web settings page to preview rename template and apply to libraries

## Testing
- `pnpm test` *(fails: Could not find '/workspace/gamearr/apps/api/dist/**/*.test.js')*
- `node --test dist/apps/api/src/organize/library.test.js`
- `node --test dist/apps/api/src/organize/preview.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4eb406a048330858bfefa981db3f2