### PR TITLE
feat(web): add DAT matching status badges and recheck prompt

### DIFF
--- a/apps/web/src/pages/SettingsPlatform.tsx
+++ b/apps/web/src/pages/SettingsPlatform.tsx
@@ -28,6 +28,7 @@ export function SettingsPlatform() {
     path: `/platforms/${id}`,
   });
   const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const [showRecheckTip, setShowRecheckTip] = useState(false);
 
   const activateMutation = useApiMutation<unknown, { datFileId: string }>(
     ({ datFileId }) => ({
@@ -38,6 +39,7 @@ export function SettingsPlatform() {
       onSuccess: () => {
         toast('Activated');
         refetch();
+        setShowRecheckTip(true);
       },
       onError: (err: ApiError) => toast.error(err.message),
     },
@@ -128,9 +130,21 @@ export function SettingsPlatform() {
         />
         {uploadProgress !== null && <div>Uploading {uploadProgress}%</div>}
       </div>
-      <Button onClick={() => recheckMutation.mutate()} disabled={recheckMutation.isPending}>
-        Re-check unmatched with active DAT
-      </Button>
+      {showRecheckTip && (
+        <div className="text-sm">
+          DAT activated.{' '}
+          <button
+            className="text-blue-500 underline"
+            onClick={() => {
+              setShowRecheckTip(false);
+              recheckMutation.mutate();
+            }}
+            disabled={recheckMutation.isPending}
+          >
+            Recheck unmatched?
+          </button>
+        </div>
+      )}
       <table className="w-full text-sm">
         <thead>
           <tr>

--- a/apps/web/src/pages/SettingsPlatforms.tsx
+++ b/apps/web/src/pages/SettingsPlatforms.tsx
@@ -28,6 +28,7 @@ export function SettingsPlatforms() {
             <th className="text-left p-2">Aliases</th>
             <th className="text-left p-2">Active DAT</th>
             <th className="text-left p-2">Activated</th>
+            <th className="text-left p-2">DAT Status</th>
             <th className="text-left p-2">Counts</th>
             <th className="p-2" />
           </tr>
@@ -42,6 +43,17 @@ export function SettingsPlatforms() {
                 {p.activeDatFile?.activatedAt
                   ? new Date(p.activeDatFile.activatedAt).toLocaleDateString()
                   : '-'}
+              </td>
+              <td className="p-2">
+                {p.activeDatFile?.activatedAt ? (
+                  <span className="bg-green-100 text-green-800 text-xs font-medium px-2 py-0.5 rounded">
+                    DAT matching active
+                  </span>
+                ) : (
+                  <span className="bg-yellow-100 text-yellow-800 text-xs font-medium px-2 py-0.5 rounded">
+                    DAT matching inactive
+                  </span>
+                )}
               </td>
               <td className="p-2">
                 {p.counts


### PR DESCRIPTION
## Summary
- show DAT matching status on settings platforms page
- prompt to recheck unmatched artifacts after activating DAT

## Testing
- `pnpm lint --filter @gamearr/web`
- `pnpm test --filter @gamearr/web`


------
https://chatgpt.com/codex/tasks/task_e_68b4f0e022848330916fa3aaa6833508