### PR TITLE
feat(domain): introduce indexer registry and types

### DIFF
--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -2,6 +2,7 @@ import { Injectable, Inject } from '@nestjs/common';
 import {
   listIndexers,
   getIndexer,
+  score,
   type IndexerResult,
   type IndexerQuery,
 } from '@gamearr/domain';
@@ -22,9 +23,7 @@ export class SearchService {
 
   private cache = new Map<string, IndexerResult>();
 
-  async search(
-    q: SearchQuery,
-  ): Promise<(IndexerResult & { indexer: string })[]> {
+  async search(q: SearchQuery): Promise<IndexerResult[]> {
     const query: IndexerQuery = {
       title: q.title ?? '',
       platform: q.platform ?? '',
@@ -40,58 +39,58 @@ export class SearchService {
           return res.map((r) => {
             const normalized: IndexerResult = {
               ...r,
-              size:
-                typeof r.size === 'number'
-                  ? r.size
-                  : r.size
-                    ? Number(r.size)
-                    : 0,
+              indexer: r.indexer ?? idx.key,
+              sizeBytes:
+                typeof r.sizeBytes === 'number'
+                  ? r.sizeBytes
+                  : r.sizeBytes
+                    ? Number(r.sizeBytes)
+                    : undefined,
               seeders:
                 typeof r.seeders === 'number'
                   ? r.seeders
                   : r.seeders
                     ? Number(r.seeders)
-                    : 0,
+                    : undefined,
+              leechers:
+                typeof r.leechers === 'number'
+                  ? r.leechers
+                  : r.leechers
+                    ? Number(r.leechers)
+                    : undefined,
               isPassworded: r.isPassworded ?? false,
             };
-            const withIndexer = { indexer: idx.name, ...normalized };
-            this.cache.set(`${idx.name}:${r.id}`, normalized);
-            return withIndexer;
+            this.cache.set(`${idx.key}:${r.id}`, normalized);
+            return normalized;
           });
         }),
       )
     ).flat();
 
-    results.sort((a, b) => {
-      if (a.isPassworded !== b.isPassworded)
-        return a.isPassworded ? 1 : -1;
-      if ((a.seeders ?? 0) !== (b.seeders ?? 0))
-        return (b.seeders ?? 0) - (a.seeders ?? 0);
-      return (a.size ?? 0) - (b.size ?? 0);
-    });
+    results.sort((a, b) => score(b) - score(a));
 
     return results;
   }
 
-  async downloadFromSearch(
-    indexerName: string,
-    id: string,
-    category?: string,
-  ) {
-    const key = `${indexerName}:${id}`;
+  async downloadFromSearch(indexerKey: string, id: string, category?: string) {
+    const key = `${indexerKey}:${id}`;
     let result = this.cache.get(key);
     if (!result) {
-      const indexer = getIndexer(indexerName);
+      const indexer = getIndexer(indexerKey);
       if (!indexer) {
         throw new Error('Indexer not found');
       }
-      const res = await indexer.search({ title: '', platform: '' });
-      result = res.find((r) => r.id === id);
+      if (indexer.getById) {
+        result = (await indexer.getById(id)) ?? undefined;
+      } else {
+        const res = await indexer.search({ title: '', platform: '', limit: 1 });
+        result = res.find((r) => r.id === id);
+      }
       if (!result) {
         throw new Error('Result not found');
       }
     }
-    if (!result.link.startsWith('magnet:')) {
+    if (!result.link || !result.link.startsWith('magnet:')) {
       throw new Error('Unsupported link');
     }
     return this.downloads.addMagnet(result.link, category);

--- a/packages/adapters/src/indexers/demo.ts
+++ b/packages/adapters/src/indexers/demo.ts
@@ -2,28 +2,31 @@ import type { Indexer, IndexerQuery, IndexerResult } from '@gamearr/domain';
 
 const data: IndexerResult[] = [
   {
+    indexer: 'demo',
     id: 'snes-1',
     title: 'Super Mario World',
     platform: 'snes',
-    size: 4096,
+    sizeBytes: 4096,
     seeders: 20,
     link: 'magnet:?xt=urn:btih:SMW',
     protocol: 'torrent',
   },
   {
+    indexer: 'demo',
     id: 'snes-2',
     title: 'The Legend of Zelda: A Link to the Past',
     platform: 'snes',
-    size: 4096,
+    sizeBytes: 4096,
     seeders: 15,
     link: 'magnet:?xt=urn:btih:ZELDA',
     protocol: 'torrent',
   },
   {
+    indexer: 'demo',
     id: 'snes-3',
     title: 'Super Metroid',
     platform: 'snes',
-    size: 4096,
+    sizeBytes: 4096,
     seeders: 10,
     link: 'magnet:?xt=urn:btih:METROID',
     protocol: 'torrent',
@@ -31,13 +34,19 @@ const data: IndexerResult[] = [
 ];
 
 export const demo: Indexer = {
-  name: 'demo',
+  name: 'Demo',
+  key: 'demo',
+  kind: 'custom',
   async search(q: IndexerQuery): Promise<IndexerResult[]> {
-    return data.filter(r => {
-      const titleMatch = !q.title || r.title.toLowerCase().includes(q.title.toLowerCase());
+    return data.filter((r) => {
+      const titleMatch =
+        !q.title || r.title.toLowerCase().includes(q.title.toLowerCase());
       const platformMatch = !q.platform || r.platform === q.platform;
       return titleMatch && platformMatch;
     });
+  },
+  async getById(id: string): Promise<IndexerResult | null> {
+    return data.find((r) => r.id === id) ?? null;
   },
 };
 

--- a/packages/domain/src/indexers/registry.ts
+++ b/packages/domain/src/indexers/registry.ts
@@ -1,15 +1,16 @@
 import type { Indexer } from './types.js';
 
-const registry = new Map<string, Indexer>();
+const REG = new Map<string, Indexer>();
 
-export function registerIndexer(indexer: Indexer): void {
-  registry.set(indexer.name, indexer);
+export function registerIndexer(ix: Indexer) {
+  REG.set(ix.key, ix);
 }
 
-export function listIndexers(): Indexer[] {
-  return Array.from(registry.values());
+export function getIndexer(key: string) {
+  return REG.get(key);
 }
 
-export function getIndexer(name: string): Indexer | undefined {
-  return registry.get(name);
+export function listIndexers() {
+  return Array.from(REG.values());
 }
+

--- a/packages/domain/src/indexers/types.ts
+++ b/packages/domain/src/indexers/types.ts
@@ -1,23 +1,49 @@
+export type Protocol = 'torrent' | 'nzb';
+
 export interface IndexerQuery {
   title: string;
-  platform: string;
+  platform: string; // internal platform slug
   year?: number;
   regionPref?: string[];
+  limit?: number;
 }
 
 export interface IndexerResult {
-  id: string;
+  indexer: string; // indexer name/id
+  id: string; // indexer-local id (or hash)
   title: string;
-  platform: string;
-  size?: number;
+  platform?: string;
+  year?: number;
+  sizeBytes?: number;
   seeders?: number;
+  leechers?: number;
+  verified?: boolean;
   isPassworded?: boolean;
-  link: string;
-  protocol: 'torrent' | 'nzb';
+  protocol: Protocol;
+  link?: string; // magnet / nzb URL if directly available
+  infoHash?: string; // optional torrent hash
+  publishedAt?: string;
   extra?: Record<string, unknown>;
 }
 
 export interface Indexer {
-  name: string;
+  name: string; // human friendly
+  key: string; // unique key
+  kind: 'torznab' | 'rss' | 'custom';
   search(q: IndexerQuery): Promise<IndexerResult[]>;
+  getById?(id: string): Promise<IndexerResult | null>;
 }
+
+export interface ScoreInput extends IndexerResult {
+  regionPref?: string[];
+}
+
+export function score(r: ScoreInput): number {
+  const seed = r.seeders ?? 0;
+  const sizePenalty = r.sizeBytes
+    ? Math.log10(r.sizeBytes / (1024 * 1024))
+    : 0;
+  const passwdPenalty = r.isPassworded ? 5 : 0;
+  return seed - sizePenalty - passwdPenalty + (r.verified ? 1 : 0);
+}
+


### PR DESCRIPTION
## Summary
- add rich indexer type definitions and scoring helper
- provide indexer registry for registration and lookup
- update demo indexer and API search service to use new structures

## Testing
- `pnpm --filter @gamearr/domain test`
- `pnpm --filter @gamearr/adapters build`
- `pnpm --filter @gamearr/api test`


------
https://chatgpt.com/codex/tasks/task_e_68b4fb0ab1fc8330866aabb453101a2b