### PR TITLE
feat: add RSS magnet indexer

### DIFF
--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -8,10 +8,13 @@
     "build": "tsc -p tsconfig.json",
     "dev": "echo dev adapters",
     "lint": "echo lint adapters",
-    "test": "echo test adapters"
+    "test": "tsc -p tsconfig.json && node --test dist"
   },
   "dependencies": {
     "fast-xml-parser": "^5.2.5",
     "@gamearr/domain": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0"
   }
 }

--- a/packages/adapters/src/index.ts
+++ b/packages/adapters/src/index.ts
@@ -5,6 +5,7 @@ import * as emulationstationModule from './exporters/emulationstation';
 import * as nointroDatModule from './dat/nointro';
 import demoIndexer from './indexers/demo.js';
 import { createTorznabIndexer } from './indexers/torznab.js';
+import { createRssMagnetIndexer } from './indexers/rssMagnet.js';
 
 // Create and export the rawg object
 export const rawg = {
@@ -31,4 +32,4 @@ export const indexers = {
   demo: demoIndexer,
 };
 
-export { createTorznabIndexer };
+export { createTorznabIndexer, createRssMagnetIndexer };

--- a/packages/adapters/src/indexers/rssMagnet.test.ts
+++ b/packages/adapters/src/indexers/rssMagnet.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createRssMagnetIndexer } from './rssMagnet.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const feedPath = path.resolve(
+  __dirname,
+  '../../../../test/fixtures/rss.xml'
+);
+const feedUrl = pathToFileURL(feedPath).href;
+
+test('filters by title and returns magnet links', async () => {
+  const ix = createRssMagnetIndexer({ key: 'test', url: feedUrl });
+  const results = await ix.search({ title: 'Mario', platform: 'snes' });
+  assert.equal(results.length, 1);
+  assert.equal(results[0].title, 'Super Mario World (SNES)');
+  assert.equal(results[0].link, 'magnet:?xt=urn:btih:SMW');
+  assert.equal(results[0].platform, 'snes');
+});

--- a/packages/adapters/src/indexers/rssMagnet.ts
+++ b/packages/adapters/src/indexers/rssMagnet.ts
@@ -1,0 +1,99 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { XMLParser } from 'fast-xml-parser';
+import type { Indexer, IndexerQuery, IndexerResult } from '@gamearr/domain';
+import { get } from '../http.js';
+
+interface RssMagnetOpts {
+  key: string;
+  name?: string;
+  url: string;
+  timeoutMs?: number;
+}
+
+export class RssMagnetIndexer implements Indexer {
+  name: string;
+  key: string;
+  kind: 'rss' = 'rss';
+  private url: string;
+  private timeoutMs: number;
+
+  constructor(opts: RssMagnetOpts) {
+    this.key = opts.key;
+    this.name = opts.name ?? opts.key;
+    this.url = opts.url;
+    this.timeoutMs = opts.timeoutMs ?? 10000;
+  }
+
+  private async fetch(): Promise<string | null> {
+    try {
+      if (this.url.startsWith('http://') || this.url.startsWith('https://')) {
+        const res = await get(this.url, { timeoutMs: this.timeoutMs });
+        if (!res.ok) return null;
+        return await res.text();
+      }
+      // file path or file url
+      const path = this.url.startsWith('file:')
+        ? fileURLToPath(this.url)
+        : this.url;
+      return await readFile(path, 'utf-8');
+    } catch {
+      return null;
+    }
+  }
+
+  async search(q: IndexerQuery): Promise<IndexerResult[]> {
+    const xml = await this.fetch();
+    if (!xml) return [];
+
+    try {
+      const parser = new XMLParser({ ignoreAttributes: false });
+      const parsed = parser.parse(xml);
+      let items: any[] = [];
+      if (parsed?.rss?.channel?.item) {
+        items = Array.isArray(parsed.rss.channel.item)
+          ? parsed.rss.channel.item
+          : [parsed.rss.channel.item];
+      } else if (parsed?.feed?.entry) {
+        items = Array.isArray(parsed.feed.entry)
+          ? parsed.feed.entry
+          : [parsed.feed.entry];
+      }
+      const titleQuery = q.title.toLowerCase();
+      const results: IndexerResult[] = [];
+      for (const item of items) {
+        const titleRaw = item.title?.['#text'] ?? item.title;
+        const title = typeof titleRaw === 'string' ? titleRaw : '';
+        let linkRaw: any = item.link;
+        if (Array.isArray(linkRaw)) linkRaw = linkRaw[0];
+        const link =
+          typeof linkRaw === 'object'
+            ? linkRaw['@_href'] ?? linkRaw['#text'] ?? linkRaw
+            : linkRaw;
+        if (typeof link !== 'string' || !link.startsWith('magnet:')) continue;
+        if (title && !title.toLowerCase().includes(titleQuery)) continue;
+        const pubDate =
+          item.pubDate || item.published || item.updated || undefined;
+        results.push({
+          indexer: this.key,
+          id: link,
+          title,
+          platform: q.platform,
+          protocol: 'torrent',
+          link,
+          publishedAt: pubDate,
+        });
+      }
+      return results;
+    } catch {
+      return [];
+    }
+  }
+}
+
+export function createRssMagnetIndexer(opts: RssMagnetOpts): RssMagnetIndexer {
+  return new RssMagnetIndexer(opts);
+}
+
+export default createRssMagnetIndexer;
+

--- a/packages/adapters/test/fixtures/rss.xml
+++ b/packages/adapters/test/fixtures/rss.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <item>
+      <title>Super Mario World (SNES)</title>
+      <link>magnet:?xt=urn:btih:SMW</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>The Legend of Zelda</title>
+      <link>magnet:?xt=urn:btih:ZELDA</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Non Magnet Link</title>
+      <link>https://example.com/file</link>
+      <pubDate>Mon, 01 Jan 2024 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,10 @@ importers:
       fast-xml-parser:
         specifier: ^5.2.5
         version: 5.2.5
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.11
 
   packages/domain:
     devDependencies:


### PR DESCRIPTION
## Summary
- implement RssMagnetIndexer to parse RSS/Atom feeds and collect magnet links
- export createRssMagnetIndexer and expose factory in adapters
- add tests for RSS magnet indexer and fixture feed

## Testing
- `pnpm --filter @gamearr/adapters test`


------
https://chatgpt.com/codex/tasks/task_e_68b4feec2eb483308b935a925b0a8951