### PR TITLE
feat(indexers): add configurable indexer management

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -16,6 +16,7 @@ import { MetricsModule } from './metrics/metrics.module.js';
 import { SupportModule } from './support/support.module.js';
 import { SearchModule } from './search/search.module.js';
 import { OrganizeModule } from './organize/organize.module.js';
+import { IndexersModule } from './indexers/indexers.module.js';
 
 @Module({
   imports: [
@@ -36,6 +37,7 @@ import { OrganizeModule } from './organize/organize.module.js';
     SupportModule,
     SearchModule,
     OrganizeModule,
+    IndexersModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/indexers/indexers.controller.ts
+++ b/apps/api/src/indexers/indexers.controller.ts
@@ -1,0 +1,78 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Inject,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { ApiBody, ApiTags } from '@nestjs/swagger';
+import { z } from 'zod';
+import { ZodValidationPipe } from '../zod-validation.pipe.js';
+import { IndexersService } from './indexers.service.js';
+
+const createSchema = z.object({
+  key: z.string(),
+  kind: z.enum(['torznab', 'rss']),
+  name: z.string(),
+  config: z.any(),
+});
+
+const updateSchema = z.object({
+  name: z.string().optional(),
+  config: z.any().optional(),
+  isEnabled: z.boolean().optional(),
+});
+
+@ApiTags('indexers')
+@Controller('indexers')
+export class IndexersController {
+  constructor(
+    @Inject(IndexersService) private readonly service: IndexersService,
+  ) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Post()
+  @ApiBody({
+    schema: {
+      properties: {
+        key: { type: 'string' },
+        kind: { type: 'string' },
+        name: { type: 'string' },
+        config: { type: 'object' },
+      },
+    },
+  })
+  create(
+    @Body(new ZodValidationPipe(createSchema))
+    body: { key: string; kind: string; name: string; config: any },
+  ) {
+    return this.service.create(body);
+  }
+
+  @Patch(':key')
+  update(
+    @Param('key') key: string,
+    @Body(new ZodValidationPipe(updateSchema))
+    body: { name?: string; config?: any; isEnabled?: boolean },
+  ) {
+    return this.service.update(key, body);
+  }
+
+  @Delete(':key')
+  remove(@Param('key') key: string) {
+    return this.service.remove(key);
+  }
+
+  @Post(':key/test')
+  test(@Param('key') key: string) {
+    return this.service.test(key);
+  }
+}
+

--- a/apps/api/src/indexers/indexers.module.ts
+++ b/apps/api/src/indexers/indexers.module.ts
@@ -1,4 +1,4 @@
-import { Module, OnModuleInit } from '@nestjs/common';
+import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module.js';
 import { IndexersService } from './indexers.service.js';
 import { IndexersController } from './indexers.controller.js';
@@ -8,11 +8,5 @@ import { IndexersController } from './indexers.controller.js';
   controllers: [IndexersController],
   providers: [IndexersService],
 })
-export class IndexersModule implements OnModuleInit {
-  constructor(private readonly service: IndexersService) {}
-
-  async onModuleInit() {
-    await this.service.bootstrap();
-  }
-}
+export class IndexersModule {}
 

--- a/apps/api/src/indexers/indexers.module.ts
+++ b/apps/api/src/indexers/indexers.module.ts
@@ -1,0 +1,18 @@
+import { Module, OnModuleInit } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module.js';
+import { IndexersService } from './indexers.service.js';
+import { IndexersController } from './indexers.controller.js';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [IndexersController],
+  providers: [IndexersService],
+})
+export class IndexersModule implements OnModuleInit {
+  constructor(private readonly service: IndexersService) {}
+
+  async onModuleInit() {
+    await this.service.bootstrap();
+  }
+}
+

--- a/apps/api/src/indexers/indexers.service.ts
+++ b/apps/api/src/indexers/indexers.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service.js';
+import { createTorznabIndexer, createRssMagnetIndexer } from '@gamearr/adapters';
+import { registerIndexer, unregisterIndexer } from '@gamearr/domain';
+
+interface IndexerConfig {
+  key: string;
+  kind: string;
+  name: string;
+  config: any;
+  isEnabled: boolean;
+}
+
+@Injectable()
+export class IndexersService {
+  constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  private buildIndexer(cfg: IndexerConfig) {
+    if (cfg.kind === 'torznab') {
+      return createTorznabIndexer({
+        key: cfg.key,
+        name: cfg.name,
+        ...(cfg.config as any),
+      });
+    }
+    if (cfg.kind === 'rss') {
+      return createRssMagnetIndexer({
+        key: cfg.key,
+        name: cfg.name,
+        ...(cfg.config as any),
+      });
+    }
+    throw new Error('unsupported indexer kind');
+  }
+
+  async bootstrap() {
+    const configs = await this.prisma.indexerConfig.findMany({
+      where: { isEnabled: true },
+    });
+    configs.forEach((cfg: IndexerConfig) =>
+      registerIndexer(this.buildIndexer(cfg)),
+    );
+  }
+
+  list() {
+    return this.prisma.indexerConfig.findMany();
+  }
+
+  async create(data: {
+    key: string;
+    kind: string;
+    name: string;
+    config: any;
+  }) {
+    const created = await this.prisma.indexerConfig.create({ data });
+    if (created.isEnabled) {
+      registerIndexer(this.buildIndexer(created));
+    }
+    return created;
+  }
+
+  async update(
+    key: string,
+    data: { name?: string; config?: any; isEnabled?: boolean },
+  ) {
+    const updated = await this.prisma.indexerConfig.update({
+      where: { key },
+      data,
+    });
+    unregisterIndexer(key);
+    if (updated.isEnabled) {
+      registerIndexer(this.buildIndexer(updated));
+    }
+    return updated;
+  }
+
+  async remove(key: string) {
+    await this.prisma.indexerConfig.delete({ where: { key } });
+    unregisterIndexer(key);
+    return { status: 'removed' };
+  }
+
+  async test(key: string) {
+    const cfg = await this.prisma.indexerConfig.findUnique({ where: { key } });
+    if (!cfg) return { ok: false, error: 'not found' };
+    try {
+      const ix = this.buildIndexer(cfg);
+      await ix.search({ title: 'test', platform: '_any_' });
+      return { ok: true };
+    } catch (err: any) {
+      return { ok: false, error: err.message };
+    }
+  }
+}
+

--- a/apps/api/src/indexers/indexers.service.ts
+++ b/apps/api/src/indexers/indexers.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, OnModuleInit } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service.js';
 import { createTorznabIndexer, createRssMagnetIndexer } from '@gamearr/adapters';
 import { registerIndexer, unregisterIndexer } from '@gamearr/domain';
@@ -12,8 +12,12 @@ interface IndexerConfig {
 }
 
 @Injectable()
-export class IndexersService {
+export class IndexersService implements OnModuleInit {
   constructor(@Inject(PrismaService) private readonly prisma: PrismaService) {}
+
+  async onModuleInit() {
+    await this.bootstrap();
+  }
 
   private buildIndexer(cfg: IndexerConfig) {
     if (cfg.kind === 'torznab') {

--- a/apps/api/types/helmet.d.ts
+++ b/apps/api/types/helmet.d.ts
@@ -1,0 +1,2 @@
+declare module 'helmet';
+

--- a/packages/domain/src/indexers/registry.ts
+++ b/packages/domain/src/indexers/registry.ts
@@ -6,6 +6,10 @@ export function registerIndexer(ix: Indexer) {
   REG.set(ix.key, ix);
 }
 
+export function unregisterIndexer(key: string) {
+  REG.delete(key);
+}
+
 export function getIndexer(key: string) {
   return REG.get(key);
 }

--- a/packages/storage/prisma/migrations/20250921000000_add_indexer_config/migration.sql
+++ b/packages/storage/prisma/migrations/20250921000000_add_indexer_config/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "IndexerConfig" (
+    "key" TEXT NOT NULL,
+    "kind" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "config" JSONB NOT NULL,
+    "is_enabled" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "IndexerConfig_pkey" PRIMARY KEY ("key")
+);

--- a/packages/storage/prisma/schema.prisma
+++ b/packages/storage/prisma/schema.prisma
@@ -116,3 +116,13 @@ model Download {
   createdAt DateTime @default(now()) @map("created_at")
   doneAt    DateTime? @map("done_at")
 }
+
+model IndexerConfig {
+  key       String   @id
+  kind      String
+  name      String
+  config    Json
+  isEnabled Boolean  @default(true) @map("is_enabled")
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+}


### PR DESCRIPTION
## Summary
- persist indexer configurations in new IndexerConfig table
- manage indexers via new API module and bootstrap registration
- support removing indexers from in-memory registry

## Testing
- `pnpm storage-generate`
- `pnpm migrate` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b501c0236883309d2bc5761bd67ef3