### PR TITLE
feat(api): improve search fan-out and scoring

### DIFF
--- a/apps/api/src/search/search.controller.ts
+++ b/apps/api/src/search/search.controller.ts
@@ -9,10 +9,11 @@ export class SearchController {
 
   @Get('search')
   search(
-    @Query('title') title = '',
+    @Query('title') title: string,
     @Query('platform') platform = '',
     @Query('year') year?: string,
     @Query('regionPref') regionPref?: string,
+    @Query('limit') limit?: string,
   ) {
     const regions = regionPref
       ? regionPref
@@ -25,6 +26,7 @@ export class SearchController {
       platform,
       year: year ? Number(year) : undefined,
       regionPref: regions,
+      limit: limit ? Number(limit) : undefined,
     });
   }
 

--- a/apps/api/src/search/search.service.test.ts
+++ b/apps/api/src/search/search.service.test.ts
@@ -1,0 +1,75 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import type { Indexer, IndexerQuery, IndexerResult } from '@gamearr/domain';
+
+class MockDownloadsService {}
+
+test('search dedupes, scores and respects limit', async () => {
+  process.env.DATA_ROOT = '/tmp';
+  process.env.DOWNLOADS_ROOT = '/tmp';
+  const { registerIndexer, unregisterIndexer, listIndexers } = await import('@gamearr/domain');
+  const { SearchService } = await import('./search.service.js');
+
+  listIndexers().forEach((ix: Indexer) => unregisterIndexer(ix.key));
+
+  const ix1: Indexer = {
+    name: 'A',
+    key: 'a',
+    kind: 'custom',
+    async search(q: IndexerQuery): Promise<IndexerResult[]> {
+      return [
+        {
+          indexer: 'a',
+          id: '1',
+          title: q.title,
+          protocol: 'torrent',
+          infoHash: 'HASH1',
+          seeders: 10,
+        },
+        {
+          indexer: 'a',
+          id: '2',
+          title: q.title,
+          protocol: 'torrent',
+          infoHash: 'UNIQUE',
+          seeders: 5,
+          link: 'magnet:?xt=urn:btih:UNIQUE',
+        },
+      ];
+    },
+  };
+  const ix2: Indexer = {
+    name: 'B',
+    key: 'b',
+    kind: 'custom',
+    async search(q: IndexerQuery): Promise<IndexerResult[]> {
+      return [
+        {
+          indexer: 'b',
+          id: '3',
+          title: q.title,
+          protocol: 'torrent',
+          infoHash: 'HASH1',
+          seeders: 20,
+          link: 'magnet:?xt=urn:btih:HASH1',
+        },
+      ];
+    },
+  };
+
+  registerIndexer(ix1);
+  registerIndexer(ix2);
+
+  const service = new SearchService(new MockDownloadsService() as any);
+  const { results } = await service.search({ title: 'Mario', platform: 'snes' });
+
+  assert.equal(results.length, 2);
+  assert.equal(results[0].infoHash, 'HASH1');
+  assert.equal(results[0].seeders, 20);
+  assert.ok(results[0].link);
+  assert.equal(results[1].infoHash, 'UNIQUE');
+  assert.ok(results[0].score >= results[1].score);
+
+  const limited = await service.search({ title: 'Mario', platform: 'snes', limit: 1 });
+  assert.equal(limited.results.length, 1);
+});

--- a/apps/api/src/search/search.service.ts
+++ b/apps/api/src/search/search.service.ts
@@ -9,10 +9,15 @@ import {
 import { DownloadsService } from '../downloads/downloads.service.js';
 
 interface SearchQuery {
-  title?: string;
+  title: string;
   platform?: string;
   year?: number;
   regionPref?: string[];
+  limit?: number;
+}
+
+interface SearchResult extends IndexerResult {
+  score: number;
 }
 
 @Injectable()
@@ -23,12 +28,14 @@ export class SearchService {
 
   private cache = new Map<string, IndexerResult>();
 
-  async search(q: SearchQuery): Promise<IndexerResult[]> {
+  async search(q: SearchQuery): Promise<{ results: SearchResult[] }> {
+    const limit = q.limit ?? 50;
     const query: IndexerQuery = {
-      title: q.title ?? '',
+      title: q.title,
       platform: q.platform ?? '',
       year: q.year,
       regionPref: q.regionPref,
+      limit,
     };
 
     const indexers = listIndexers();
@@ -67,9 +74,45 @@ export class SearchService {
       )
     ).flat();
 
-    results.sort((a, b) => score(b) - score(a));
+    const dedup = new Map<string, IndexerResult>();
 
-    return results;
+    for (const r of results) {
+      const key = r.infoHash ? `hash:${r.infoHash}` : `id:${r.indexer}:${r.id}`;
+      const existing = dedup.get(key);
+      if (existing) {
+        if (!existing.link && r.link) {
+          existing.indexer = r.indexer;
+          existing.id = r.id;
+          existing.link = r.link;
+        }
+        if (typeof r.seeders === 'number') {
+          existing.seeders = Math.max(existing.seeders ?? 0, r.seeders);
+        }
+        if (typeof r.leechers === 'number') {
+          existing.leechers = Math.max(existing.leechers ?? 0, r.leechers);
+        }
+        if (existing.sizeBytes === undefined && r.sizeBytes !== undefined) {
+          existing.sizeBytes = r.sizeBytes;
+        }
+        if (!existing.verified && r.verified) {
+          existing.verified = r.verified;
+        }
+        if (!existing.isPassworded && r.isPassworded) {
+          existing.isPassworded = r.isPassworded;
+        }
+      } else {
+        dedup.set(key, { ...r });
+      }
+    }
+
+    const scored: SearchResult[] = Array.from(dedup.values()).map((r) => ({
+      ...r,
+      score: score({ ...r, regionPref: q.regionPref }),
+    }));
+
+    scored.sort((a, b) => b.score - a.score);
+
+    return { results: scored.slice(0, limit) };
   }
 
   async downloadFromSearch(indexerKey: string, id: string, category?: string) {


### PR DESCRIPTION
## Summary
- add optional limit to search controller and service
- dedupe, score and sort indexer results
- add unit test for search dedupe and limit

## Testing
- `pnpm test`
- `pnpm --filter @gamearr/api exec tsx src/search/search.service.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b5063990c883309c74f814ac7efbdc