### PR TITLE
fix(storage): require platform arrays

### DIFF
--- a/packages/storage/prisma/migrations/20250922000000_require_platform_arrays/migration.sql
+++ b/packages/storage/prisma/migrations/20250922000000_require_platform_arrays/migration.sql
@@ -1,0 +1,5 @@
+-- Ensure Platform array fields are required
+UPDATE "Platform" SET "extensions" = ARRAY[]::TEXT[] WHERE "extensions" IS NULL;
+UPDATE "Platform" SET "aliases" = ARRAY[]::TEXT[] WHERE "aliases" IS NULL;
+ALTER TABLE "Platform" ALTER COLUMN "extensions" SET NOT NULL;
+ALTER TABLE "Platform" ALTER COLUMN "aliases" SET NOT NULL;


### PR DESCRIPTION
## Summary
- require Platform arrays via migration

## Testing
- `pnpm lint`
- `pnpm test`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 pnpm --filter @gamearr/storage exec prisma generate`


------
https://chatgpt.com/codex/tasks/task_e_68b50d09a16883309dabce15163491bb