### PR TITLE
fix(storage): add missing migration for indexer config updatedAt

### DIFF
--- a/packages/storage/prisma/migrations/20250901033858_drop_indexer_config_updated_at_default/migration.sql
+++ b/packages/storage/prisma/migrations/20250901033858_drop_indexer_config_updated_at_default/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "IndexerConfig" ALTER COLUMN "updated_at" DROP DEFAULT;


### PR DESCRIPTION
## Summary
- drop default value from `IndexerConfig.updated_at`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b515d754908330b58ca04a9c5ff8f2