### PR TITLE
fix: handle missing indexer config table

### DIFF
--- a/packages/storage/prisma/migrations/20250901033858_drop_indexer_config_updated_at_default/migration.sql
+++ b/packages/storage/prisma/migrations/20250901033858_drop_indexer_config_updated_at_default/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "IndexerConfig" ALTER COLUMN "updated_at" DROP DEFAULT;
+ALTER TABLE IF EXISTS "IndexerConfig" ALTER COLUMN "updated_at" DROP DEFAULT;

--- a/packages/storage/prisma/migrations/20250921000000_add_indexer_config/migration.sql
+++ b/packages/storage/prisma/migrations/20250921000000_add_indexer_config/migration.sql
@@ -6,6 +6,6 @@ CREATE TABLE "IndexerConfig" (
     "config" JSONB NOT NULL,
     "is_enabled" BOOLEAN NOT NULL DEFAULT true,
     "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
     CONSTRAINT "IndexerConfig_pkey" PRIMARY KEY ("key")
 );


### PR DESCRIPTION
## Summary
- handle missing IndexerConfig table in drop default migration
- remove default from updated_at when creating IndexerConfig

## Testing
- `DATABASE_URL=postgres://localhost:5432/gamearr pnpm --filter @gamearr/storage exec prisma migrate reset --force` *(fails: Can't reach database server)*
- `pnpm --filter @gamearr/storage test`
- `pnpm --filter @gamearr/storage lint`
- `pnpm --filter @gamearr/storage build`


------
https://chatgpt.com/codex/tasks/task_e_68b51804abb88330869a09580be1adc8