### PR TITLE
feat(web): enhance search page results

### DIFF
--- a/.changeset/search-result-columns.md
+++ b/.changeset/search-result-columns.md
@@ -1,0 +1,4 @@
+---
+"@gamearr/web": patch
+---
+Enhance search page with required title, score & publish date columns, unified add-to-downloads, and indexer setup CTA.


### PR DESCRIPTION
## Summary
- require title for search
- show CTA when no indexers enabled
- display published date and score in results
- send downloads via `/downloads/from-search`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b51e4626c083309b1d47f1fd5000cb