### PR TITLE
Fix provider settings persistence and qBittorrent test connection

### DIFF
--- a/apps/api/src/downloads/downloads.controller.ts
+++ b/apps/api/src/downloads/downloads.controller.ts
@@ -18,6 +18,13 @@ const fromSearchSchema = z
   })
   .refine((d) => d.id || d.link, { message: 'id or link required' });
 
+const clientSchema = z.object({
+  baseUrl: z.string().optional(),
+  username: z.string().optional(),
+  password: z.string().optional(),
+  category: z.string().optional(),
+});
+
 @ApiTags('downloads')
 @Controller('downloads')
 export class DownloadsController {
@@ -62,9 +69,19 @@ export class DownloadsController {
     return this.service.list();
   }
 
-  @Get('test')
-  test() {
-    return this.service.test();
+  @Post('test')
+  @ApiBody({
+    schema: {
+      properties: {
+        baseUrl: { type: 'string', nullable: true },
+        username: { type: 'string', nullable: true },
+        password: { type: 'string', nullable: true },
+        category: { type: 'string', nullable: true },
+      },
+    },
+  })
+  test(@Body(new ZodValidationPipe(clientSchema)) body: any) {
+    return this.service.test(body);
   }
 
   @Post(':id/pause')

--- a/apps/api/src/downloads/downloads.service.ts
+++ b/apps/api/src/downloads/downloads.service.ts
@@ -147,9 +147,24 @@ export class DownloadsService {
     return { status: 'removed' };
   }
 
-  async test() {
+  async test(opts?: {
+    baseUrl?: string;
+    username?: string;
+    password?: string;
+    category?: string;
+  }) {
     try {
-      const client = await this.getClient();
+      let client: QbitClient;
+      if (opts?.baseUrl && opts?.username && opts?.password) {
+        client = new QbitClient({
+          baseURL: opts.baseUrl,
+          username: opts.username,
+          password: opts.password,
+          category: opts.category,
+        });
+      } else {
+        client = await this.getClient();
+      }
       await client.listTorrents();
       return { ok: true };
     } catch (err: any) {

--- a/apps/web/src/pages/SettingsProviders.tsx
+++ b/apps/web/src/pages/SettingsProviders.tsx
@@ -101,20 +101,18 @@ export function SettingsProviders() {
 
   const handleSave = async () => {
     try {
-      await Promise.all([
-        saveProviders.mutateAsync({
-          providers: { rawgKey, igdbClientId, igdbClientSecret, tgdbApiKey },
-          downloads: { transmission: tr, sab },
-          features: { experimental },
-        }),
-        saveQb.mutateAsync(qb),
-      ]);
+      await saveProviders.mutateAsync({
+        providers: { rawgKey, igdbClientId, igdbClientSecret, tgdbApiKey },
+        downloads: { transmission: tr, sab },
+        features: { experimental },
+      });
+      await saveQb.mutateAsync(qb);
       toast('Settings saved');
     } catch {}
   };
 
   const testQb = () => {
-    qbTest.mutate(undefined, {
+    qbTest.mutate(qb, {
       onSuccess: (res) => {
         if (res.ok) toast('Connection OK');
         else toast.error('Connection failed');
@@ -123,7 +121,10 @@ export function SettingsProviders() {
     });
   };
 
-  const qbTest = useApiMutation<{ ok: boolean }>(() => ({ path: '/downloads/test' }));
+  const qbTest = useApiMutation<{ ok: boolean }, DownloadClient>((body) => ({
+    path: '/downloads/test',
+    init: { method: 'POST', body: JSON.stringify(body) },
+  }));
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- prevent provider settings from being overwritten when saving
- allow testing qBittorrent connection with current form credentials

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68b523b302448330809274ae2a5095fe